### PR TITLE
Add NAME argument to the MSOffice2016URLandUpdateInfoProvider processor

### DIFF
--- a/MSOffice2016/MSExcel2016.pkg.recipe
+++ b/MSOffice2016/MSExcel2016.pkg.recipe
@@ -29,6 +29,8 @@ http://msdn.microsoft.com/en-us/library/ee825488(v=cs.20).aspx for a table of Cu
             <dict>
                 <key>product</key>
                 <string>Excel</string>
+                <key>munki_update_name</key>
+                <string>%NAME%</string>
             </dict>
         </dict>
         <dict>

--- a/MSOffice2016/MSOneNote.pkg.recipe
+++ b/MSOffice2016/MSOneNote.pkg.recipe
@@ -26,6 +26,8 @@ http://msdn.microsoft.com/en-us/library/ee825488(v=cs.20).aspx for a table of Cu
             <dict>
                 <key>product</key>
                 <string>OneNote</string>
+                <key>munki_update_name</key>
+                <string>%NAME%</string>
             </dict>
         </dict>
         <dict>

--- a/MSOffice2016/MSPowerpoint2016.pkg.recipe
+++ b/MSOffice2016/MSPowerpoint2016.pkg.recipe
@@ -29,6 +29,8 @@ http://msdn.microsoft.com/en-us/library/ee825488(v=cs.20).aspx for a table of Cu
             <dict>
                 <key>product</key>
                 <string>PowerPoint</string>
+                <key>munki_update_name</key>
+                <string>%NAME%</string>
             </dict>
         </dict>
         <dict>

--- a/MSOffice2016/MSWord2016.pkg.recipe
+++ b/MSOffice2016/MSWord2016.pkg.recipe
@@ -29,6 +29,8 @@ http://msdn.microsoft.com/en-us/library/ee825488(v=cs.20).aspx for a table of Cu
             <dict>
                 <key>product</key>
                 <string>Word</string>
+                <key>munki_update_name</key>
+                <string>%NAME%</string>
             </dict>
         </dict>
         <dict>


### PR DESCRIPTION
The NAME value specified in the overrides for the MSExcel2016.munki, MSOneNote.munki, MSPowerPoint2016.munki and MSWord2016.munki recipes is being ignored. Adding munki_update_name to the MSOffice2016URLandUpdateInfoProvider arguments list in the respective pkg recipes for these 4 products will resolve the issue.