### PR TITLE
Charles URL and Regex Change

### DIFF
--- a/CharlesProxy/CharlesProxy.download.recipe
+++ b/CharlesProxy/CharlesProxy.download.recipe
@@ -11,7 +11,7 @@
 		<key>NAME</key>
 		<string>CharlesProxy</string>
 		<key>URL</key>
-		<string>http://www.charlesproxy.com/latest-release/download.do</string>
+		<string>http://www.charlesproxy.com/latest.do</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.4.0</string>
@@ -25,7 +25,7 @@
 				<key>url</key>
 				<string>%URL%</string>
 				<key>re_pattern</key>
-				<string>\d+\.\d+\.\d+</string>
+				<string>.*</string>
 			</dict>
 		</dict>
 		<dict>


### PR DESCRIPTION
Using the same URL that Charles itself uses to determine update
availability. Also changing the regex to follow suit.