### PR TITLE
Use HTTPS to fetch Bartender

### DIFF
--- a/Bartender/Bartender.download.recipe
+++ b/Bartender/Bartender.download.recipe
@@ -7,9 +7,9 @@
 
 The SPARKLE_FEED_URL input variable can be overridden to determine which major version of Bartender you want to download.
   - For Bartender v1.x, use this SPARKLE_FEED_URL:
-    http://www.macbartender.com/updates/Appcast.xml
+    https://www.macbartender.com/updates/Appcast.xml
   - For Bartender v2.x, use this SPARKLE_FEED_URL:
-    http://www.macbartender.com/B2/updates/Appcast.xml
+    https://www.macbartender.com/B2/updates/Appcast.xml
 
 The Sparkle feed for v1.x is the default.</string>
     <key>Identifier</key>
@@ -21,7 +21,7 @@ The Sparkle feed for v1.x is the default.</string>
         <key>NAME</key>
         <string>Bartender</string>
         <key>SPARKLE_FEED_URL</key>
-        <string>http://www.macbartender.com/updates/Appcast.xml</string>
+        <string>https://www.macbartender.com/updates/Appcast.xml</string>
         <key>USER_AGENT</key>
         <string>Mozilla/5.0</string>
 	</dict>


### PR DESCRIPTION
The sparkle feed for Bartender is now served over HTTPS, and plain requests receive HTTP 302. AutoPkg doesn't deal with this gracefully so instead the recipe fails! :( Here's a minor change to the download recipe which should sort that out.