### PR TITLE
Removed sparkle and added OSX type user-agent to URLDownloader

### DIFF
--- a/Atlassian/HipChat.download.recipe
+++ b/Atlassian/HipChat.download.recipe
@@ -12,27 +12,25 @@
     <dict>
         <key>NAME</key>
         <string>HipChat</string>
-        <key>SPARKLE_FEED_URL</key>
-        <string>https://www.hipchat.com/release_notes/appcast/mac</string>
-	</dict>
+        <key>DOWNLOAD_URL</key>
+        <string>https://www.hipchat.com/downloads/latest/mac</string>
+        </dict>
     <key>Process</key>
     <array>
-        <dict>
-            <key>Processor</key>
-            <string>SparkleUpdateInfoProvider</string>
-            <key>Arguments</key>
-            <dict>
-                <key>appcast_url</key>
-                <string>%SPARKLE_FEED_URL%</string>
-            </dict>
-        </dict>
         <dict>
             <key>Processor</key>
             <string>URLDownloader</string>
             <key>Arguments</key>
             <dict>
+                <key>url</key>
+                <string>%DOWNLOAD_URL%</string>
                 <key>filename</key>
                 <string>%NAME%.zip</string>
+                <key>request_headers</key>
+                <dict>
+                        <key>user-agent</key>
+                        <string>Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2227.1 Safari/537.36</string>
+                </dict>
             </dict>
         </dict>
         <dict>


### PR DESCRIPTION
Seems to work now. Having same problem as #44 

User-agent was necessary to get a version higher then 3.2.1 for some reason.

