### PR TITLE
Added Identifier Key

### DIFF
--- a/santa/santa.install.recipe
+++ b/santa/santa.install.recipe
@@ -5,6 +5,7 @@
 	<key>Description</key>
 	<string>Installs the current (still in prerelease) version of santa from Github.
 	</string>
+	<key>Identifier</key>
 	<string>com.github.autopkg.arubdesu.install.santa</string>
 	<key>Input</key>
 	<dict>


### PR DESCRIPTION
Autopkg was throwing the below error causing all of our autopkg Jenkins jobs to fail (and send out e-mail notifications to our team) -- I should really figure out how to fix that ;-)  

WARNING: plist error for /Users/Shared/Autopkg/RecipeRepos/com.github.autopkg.arubdesu-recipes/santa/santa.install.recipe: Error Domain=NSCocoaErrorDomain Code=3840 "The data couldn’t be read because it isn’t in the correct format." (Found non-key inside <dict> at line 8) UserInfo=0x7fcd31e06e90 {NSDebugDescription=Found non-key inside <dict> at line 8, kCFPropertyListOldStyleParsingError=The data couldn’t be read because it isn’t in the correct format.}