### PR TITLE
Change path to Charles Proxy Settings

### DIFF
--- a/CharlesProxy/CharlesProxy.pkg.recipe
+++ b/CharlesProxy/CharlesProxy.pkg.recipe
@@ -78,7 +78,7 @@
 						</dict>
 						<dict>
 							<key>path</key>
-							<string>Applications/Charles.app/Contents/MacOS/Charles Proxy Settings</string>
+							<string>Applications/Charles.app/Contents/Resources/Charles Proxy Settings</string>
 							<key>user</key>
 							<string>root</string>
 							<key>group</key>


### PR DESCRIPTION
v.3.11.5 has changed the location of the `Charles Proxy Settings` binary from `Charles.app/Contents/MacOS` to `Charles.app/Contents/Resources`. Updated `PkgCreator` permission steps to reflect this.