### PR TITLE
Fixed for Lingon X 4

### DIFF
--- a/PeterBorgApps/LingonX.download.recipe
+++ b/PeterBorgApps/LingonX.download.recipe
@@ -13,9 +13,7 @@
         <key>NAME</key>
         <string>LingonX</string>
         <key>SPARKLE_FEED_URL</key>
-        <string>https://www.peterborgapps.com/updates/lingonx2-appcast.xml</string>
-        <key>USER_AGENT</key>
-        <string>Lingon X Sparkle</string>
+        <string>https://www.peterborgapps.com/updates/lingonx4-appcast.xml</string>
     </dict>
     <key>Process</key>
     <array>
@@ -26,11 +24,6 @@
             <dict>
                 <key>appcast_url</key>
                 <string>%SPARKLE_FEED_URL%</string>
-                <key>appcast_request_headers</key>
-                <dict>
-                    <key>user-agent</key>
-                    <string>%USER_AGENT%</string>
-                </dict>
             </dict>
         </dict>
         <dict>
@@ -67,7 +60,7 @@
                 <key>input_path</key>
                 <string>%RECIPE_CACHE_DIR%/%NAME%/Lingon X.app</string>
                 <key>requirement</key>
-                <string>anchor apple generic and identifier "com.peterborgapps.LingonX2" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = HT76L9L9RG)</string>
+                <string>anchor apple generic and identifier "com.peterborgapps.LingonX4" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = HT76L9L9RG)</string>
             </dict>
         </dict>
     </array>

--- a/PeterBorgApps/LingonX.pkg.recipe
+++ b/PeterBorgApps/LingonX.pkg.recipe
@@ -52,7 +52,7 @@
             <key>Arguments</key>
             <dict>
                 <key>input_plist_path</key>
-                <string>%pkgroot%/Applications/LingonX.app/Contents/Info.plist</string>
+                <string>%pkgroot%/Applications/Lingon X.app/Contents/Info.plist</string>
                 <key>plist_version_key</key>
                 <string>CFBundleShortVersionString</string>
             </dict>


### PR DESCRIPTION
Adjusted download recipe's Sparkle feed URL, removed the appcast_request_headers, and adjusted the code signing requirement.

Changed the path of the "Lingon X" application in the pkg recipe since the application now has a space before the "X" in it's name.