### PR TITLE
Fixing HipChat.munki

### DIFF
--- a/Atlassian/HipChat.munki.recipe
+++ b/Atlassian/HipChat.munki.recipe
@@ -26,30 +26,15 @@
             <string>%NAME%</string>
             <key>name</key>
             <string>%NAME%</string>
-            <key>blocking_applications</key>
-            <array>
-            	<string>%NAME%</string>
-            </array>
         </dict>
     </dict>
     <key>Process</key>
     <array>
         <dict>
-            <key>Processor</key>
-            <string>DmgCreator</string>
-            <key>Arguments</key>
-            <dict>
-                <key>dmg_root</key>
-                <string>%RECIPE_CACHE_DIR%/%NAME%</string>
-                <key>dmg_path</key>
-                <string>%RECIPE_CACHE_DIR%/%NAME%.dmg</string>
-            </dict>
-        </dict>
-        <dict>
             <key>Arguments</key>
             <dict>
                 <key>pkg_path</key>
-                <string>%dmg_path%</string>
+                <string>%pathname%</string>
                 <key>repo_subdirectory</key>
                 <string>%MUNKI_REPO_SUBDIR%</string>
             </dict>


### PR DESCRIPTION
Changed from a pkg recipe to a copy_from_dmg, including adjusting the
MunkiImport path and removing DmgCreator.  Also pulled the
blocking_application since it comes for “free” with copy_from_dmg.