### PR TITLE
Update MacID.download to use sparkle feed

### DIFF
--- a/MacID/MacID.download.recipe
+++ b/MacID/MacID.download.recipe
@@ -15,25 +15,20 @@
 	<string>0.4.0</string>
 	<key>Process</key>
 	<array>
-		<dict>
-			<key>Processor</key>
-			<string>URLTextSearcher</string>
-			<key>Arguments</key>
-			<dict>
-				<!--  "public_version": "1.3.1.1", -->
-				<key>url</key>
-				<string>https://macid.co/api/v1/version/</string>
-				<key>re_pattern</key>
-				<string> "public_version"\: "(.+)"</string>
-			</dict>
-		</dict>
+	    <dict>
+            <key>Processor</key>
+            <string>SparkleUpdateInfoProvider</string>
+            <key>Arguments</key>
+            <dict>
+                <key>appcast_url</key>
+                <string>https://macid.co/appcast.xml</string>
+            </dict>
+        </dict>
 		<dict>
 			<key>Processor</key>
 			<string>URLDownloader</string>
 			<key>Arguments</key>
 			<dict>
-				<key>url</key>
-				<string>http://macid.co/app/%match%/MacID-for-OS-X.zip</string>
 				<key>filename</key>
 				<string>%NAME%.zip</string>
 			</dict>


### PR DESCRIPTION
Update download recipe for MacID to move from plain text search to Sparkle feed