### PR TITLE
Improving Fluid.munki's Versioning

### DIFF
--- a/CelestialTeapotSoftware/Fluid.munki.recipe
+++ b/CelestialTeapotSoftware/Fluid.munki.recipe
@@ -48,10 +48,6 @@
             </dict>
         </dict>
         <dict>
-            <key>Processor</key>
-            <string>MunkiPkginfoMerger</string>
-        </dict>
-        <dict>
             <key>Arguments</key>
             <dict>
                 <key>pkg_path</key>

--- a/CelestialTeapotSoftware/Fluid.munki.recipe
+++ b/CelestialTeapotSoftware/Fluid.munki.recipe
@@ -58,6 +58,8 @@
                 <string>%dmg_path%</string>
                 <key>repo_subdirectory</key>
                 <string>%MUNKI_REPO_SUBDIR%</string>
+                <key>version_comparison_key</key>
+                <string>CFBundleVersion</string>
             </dict>
             <key>Processor</key>
             <string>MunkiImporter</string>

--- a/CelestialTeapotSoftware/Fluid.munki.recipe
+++ b/CelestialTeapotSoftware/Fluid.munki.recipe
@@ -35,6 +35,32 @@
     <key>Process</key>
     <array>
         <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>info_path</key>
+                <string>%RECIPE_CACHE_DIR%/%NAME%/Fluid.app/Contents/Info.plist</string>
+                <key>plist_keys</key>
+                <dict>
+                    <key>CFBundleVersion</key>
+                    <string>build_number</string>
+                </dict>
+            </dict>
+            <key>Processor</key>
+            <string>PlistReader</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>additional_pkginfo</key>
+                <dict>
+                    <key>version</key>
+                    <string>%version%.%build_number%</string>
+                </dict>
+            </dict>
+            <key>Processor</key>
+            <string>MunkiPkginfoMerger</string>
+        </dict>
+        <dict>
             <key>Processor</key>
             <string>DmgCreator</string>
             <key>Arguments</key>


### PR DESCRIPTION
Fluid seems to frequently be released with the same CFBundleShortVersionString but an updated CFBundleVersion.  Improve Fluid.munki’s version handling.