### PR TITLE
Add URL encoding to pkg filename

### DIFF
--- a/SharedProcessors/ShoveStuffInABucket.py
+++ b/SharedProcessors/ShoveStuffInABucket.py
@@ -17,6 +17,7 @@
 import os
 import plistlib
 import subprocess
+import urllib
 
 from autopkglib import Processor, ProcessorError
 
@@ -80,7 +81,8 @@ class ShoveStuffInABucket(Processor):
            Also makes sure unstable as only catalog in case override missed it"""
         simimport = '/usr/local/bin/shoveplist'
         existing_dict = plistlib.readPlist(pkginfo_repo_path)
-        existing_dict['PackageCompleteURL'] = cloudfrontprefix + justpkg
+        justpkg_encoded = urllib.quote(justpkg)
+        existing_dict['PackageCompleteURL'] = cloudfrontprefix + justpkg_encoded
         existing_dict['catalogs'] = ['unstable']
         plistlib.writePlist(existing_dict, pkginfo_repo_path)
         cmd = [simimport, '-pkgname', justpkg, '-pkgsinfo', pkginfo_repo_path, '-gcp.project', gcloudapp]


### PR DESCRIPTION
Munki clients will fail to download a pkg from an S3 bucket if the pkg
filename contains spaces. Added URL encoding of the pkg filename that
goes into PackageCompleteURL.