### PR TITLE
Fix test of pkg existence in S3 bucket

### DIFF
--- a/SharedProcessors/ShoveStuffInABucket.py
+++ b/SharedProcessors/ShoveStuffInABucket.py
@@ -104,7 +104,7 @@ class ShoveStuffInABucket(Processor):
         justpkg = os.path.basename(pkg_repo_path)
         bukkit = self.env['bucket']
         gcloudapp = self.env['gcloudapp']
-        shoveit = self.check(bukkit, pkg_repo_path)
+        shoveit = self.check(bukkit, justpkg)
         esthreeurl = 's3://'+ bukkit + '/'
         cloudfrontprefix = self.env['cloudfrontprefix']
         if shoveit:


### PR DESCRIPTION
Previously when testing if a pkg was already in the S3 bucket, the
full local path of the pkg was passed to AWS. This resulted in the test
always indicating the file did not already exist. Now during the test
only the basename of the pkg is passed to AWS.