### PR TITLE
CharlesProxy.install recipe - remove Name input key

### DIFF
--- a/CharlesProxy/CharlesProxy.install.recipe
+++ b/CharlesProxy/CharlesProxy.install.recipe
@@ -7,10 +7,7 @@
 	<key>Identifier</key>
 	<string>com.github.autopkg.arubdesu.install.CharlesProxy</string>
 	<key>Input</key>
-	<dict>
-		<key>Name</key>
-		<string>CharlesProxy</string>
-	</dict>
+	<dict/>
 	<key>MinimumVersion</key>
 	<string>0.4.0</string>
 	<key>ParentRecipe</key>


### PR DESCRIPTION
The Name key is not needed for this recipe; having NAME and Name in the override also causes confusion.