### PR TITLE
Fix Versioning for Fluid

### DIFF
--- a/CelestialTeapotSoftware/Fluid.munki.recipe
+++ b/CelestialTeapotSoftware/Fluid.munki.recipe
@@ -35,32 +35,6 @@
     <key>Process</key>
     <array>
         <dict>
-            <key>Arguments</key>
-            <dict>
-                <key>info_path</key>
-                <string>%RECIPE_CACHE_DIR%/%NAME%/Fluid.app/Contents/Info.plist</string>
-                <key>plist_keys</key>
-                <dict>
-                    <key>CFBundleVersion</key>
-                    <string>build_number</string>
-                </dict>
-            </dict>
-            <key>Processor</key>
-            <string>PlistReader</string>
-        </dict>
-        <dict>
-            <key>Arguments</key>
-            <dict>
-                <key>additional_pkginfo</key>
-                <dict>
-                    <key>version</key>
-                    <string>%version%.%build_number%</string>
-                </dict>
-            </dict>
-            <key>Processor</key>
-            <string>MunkiPkginfoMerger</string>
-        </dict>
-        <dict>
             <key>Processor</key>
             <string>DmgCreator</string>
             <key>Arguments</key>


### PR DESCRIPTION
The concatenation of version+build gives Munki some heartburn when
evaluating the resulting version.  Version 2.1.2, build 2120 gives a
resulting version of 2.1.2.2120.  Version 2.1, build 2104 gives a
resulting version of 2.1.2104.  2.1.2104 > 2.1.2.2120.