### PR TITLE
Disable strict verification for WWDC download recipe

### DIFF
--- a/WWDC/WWDC.download.recipe
+++ b/WWDC/WWDC.download.recipe
@@ -61,6 +61,8 @@
 				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/%NAME%.app</string>
 				<key>requirement</key>
 				<string>anchor apple generic and identifier "io.wwdc.app" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "8C7439RJLG")</string>
+				<key>strict_verification</key>
+				<false/>
 			</dict>
 			<key>Processor</key>
 			<string>CodeSignatureVerifier</string>


### PR DESCRIPTION
Yep, you're right - this totally worked. Thanks!