### PR TITLE
Remove NAME variable from app paths

### DIFF
--- a/Atlassian/HipChat.download.recipe
+++ b/Atlassian/HipChat.download.recipe
@@ -52,7 +52,7 @@
             <key>Arguments</key>
             <dict>
                 <key>input_path</key>
-                <string>%RECIPE_CACHE_DIR%/downloads/%NAME%.dmg/%NAME%.app</string>
+                <string>%RECIPE_CACHE_DIR%/downloads/%NAME%.dmg/HipChat.app</string>
                 <key>requirement</key>
                 <string>anchor apple generic and identifier "com.hipchat.HipChat" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = SDLYW7A8F3)</string>
             </dict>

--- a/Atlassian/HipChat.pkg.recipe
+++ b/Atlassian/HipChat.pkg.recipe
@@ -37,9 +37,9 @@
             <key>Arguments</key>
             <dict>
                 <key>source_path</key>
-                <string>%pathname%/%NAME%.app</string>
+                <string>%pathname%/HipChat.app</string>
                 <key>destination_path</key>
-                <string>%pkgroot%/Applications/%NAME%.app</string>
+                <string>%pkgroot%/Applications/HipChat.app</string>
             </dict>
         </dict>
         <dict>

--- a/CelestialTeapotSoftware/Fake.download.recipe
+++ b/CelestialTeapotSoftware/Fake.download.recipe
@@ -58,7 +58,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_path</key>
-				<string>%RECIPE_CACHE_DIR%/downloads/%NAME%.app</string>
+				<string>%RECIPE_CACHE_DIR%/downloads/Fake.app</string>
 				<key>requirement</key>
 				<string>anchor apple generic and identifier "com.fakeapp.Fake" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "9867TNT66D")x</string>
 			</dict>

--- a/Google PythonAppEngineSDK/GoogleAppEngineLauncher.download.recipe
+++ b/Google PythonAppEngineSDK/GoogleAppEngineLauncher.download.recipe
@@ -47,7 +47,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_path</key>
-				<string>%pathname%/%NAME%.app</string>
+				<string>%pathname%/GoogleAppEngineLauncher.app</string>
 				<key>requirement</key>
 				<string>anchor apple generic and identifier "com.google.GoogleAppEngineLauncher" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = EQHXZ8M8AV)</string>
 			</dict>

--- a/Google PythonAppEngineSDK/GoogleAppEngineLauncher.install.recipe
+++ b/Google PythonAppEngineSDK/GoogleAppEngineLauncher.install.recipe
@@ -30,7 +30,7 @@
 						<key>destination_path</key>
 						<string>/Applications</string>
 						<key>source_item</key>
-						<string>%NAME%.app</string>
+						<string>GoogleAppEngineLauncher.app</string>
 					</dict>
 				</array>
 			</dict>

--- a/Google PythonAppEngineSDK/GoogleAppEngineLauncher.pkg.recipe
+++ b/Google PythonAppEngineSDK/GoogleAppEngineLauncher.pkg.recipe
@@ -39,9 +39,9 @@
 			<key>Arguments</key>
 			<dict>
 				<key>destination_path</key>
-				<string>%pkgroot%/Applications/%NAME%.app</string>
+				<string>%pkgroot%/Applications/GoogleAppEngineLauncher.app</string>
 				<key>source_path</key>
-				<string>%pathname%/%NAME%.app</string>
+				<string>%pathname%/GoogleAppEngineLauncher.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>Copier</string>

--- a/IrradiatedSoftware/Cinch.download.recipe
+++ b/IrradiatedSoftware/Cinch.download.recipe
@@ -58,7 +58,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%.app</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/Cinch.app</string>
 				<key>requirement</key>
 				<string>identifier "com.irradiatedsoftware.Cinch-Direct" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = GVZ7RF955D</string>
 			</dict>

--- a/Limechat/Limechat.download.recipe
+++ b/Limechat/Limechat.download.recipe
@@ -58,7 +58,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%.app</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/Limechat.app</string>
 				<key>requirement</key>
 				<string>anchor apple generic and identifier "net.limechat.LimeChat" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "3723UA4YHT")</string>
 			</dict>

--- a/MacID/MacID.download.recipe
+++ b/MacID/MacID.download.recipe
@@ -56,7 +56,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%.app</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/MacID.app</string>
 				<key>requirement</key>
 				<string>anchor apple generic and identifier "com.kanecheshire.MacIDOSX" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "9BCL7VAFF4")</string>
 			</dict>

--- a/Mactracker/Mactracker.download.recipe
+++ b/Mactracker/Mactracker.download.recipe
@@ -58,7 +58,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%.app</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/Mactracker.app</string>
 				<key>requirement</key>
 				<string>identifier "com.mactrackerapp.Mactracker" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "63TP32R3AB"</string>
 			</dict>

--- a/Pacifist/Pacifist.download.recipe
+++ b/Pacifist/Pacifist.download.recipe
@@ -54,7 +54,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_path</key>
-				<string>%pathname%/%NAME%.app</string>
+				<string>%pathname%/Pacifist.app</string>
 				<key>requirement</key>
 				<string>identifier "com.charlessoft.pacifist" and anchor apple generic and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = HRLUCP7QP4)</string>
 			</dict>

--- a/Pacifist/Pacifist.pkg.recipe
+++ b/Pacifist/Pacifist.pkg.recipe
@@ -46,9 +46,9 @@
             <key>Arguments</key>
             <dict>
                 <key>source_path</key>
-                <string>%pathname%/%NAME%.app</string>
+                <string>%pathname%/Pacifist.app</string>
                 <key>destination_path</key>
-                <string>%pkgroot%/Applications/%NAME%.app</string>
+                <string>%pkgroot%/Applications/Pacifist.app</string>
             </dict>
         </dict>
         <dict>

--- a/QuickRadar/quickradar.download.recipe
+++ b/QuickRadar/quickradar.download.recipe
@@ -58,7 +58,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%.app</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/quickradar.app</string>
 				<key>requirement</key>
 				<string>anchor apple generic and identifier "com.quickradar.QuickRadar" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = R8P9272974)</string>
 			</dict>

--- a/RedSweater/MarsEdit.download.recipe
+++ b/RedSweater/MarsEdit.download.recipe
@@ -58,7 +58,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%.app</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/MarsEdit.app</string>
 				<key>requirement</key>
 				<string>(anchor apple generic and certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "493CVA9A35") and (identifier "com.red-sweater.marsedit.macappstore" or identifier "com.red-sweater.marsedit")</string>
 			</dict>

--- a/Reflector/Reflector.download.recipe
+++ b/Reflector/Reflector.download.recipe
@@ -54,7 +54,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_path</key>
-				<string>%pathname%/%NAME%.app</string>
+				<string>%pathname%/Reflector.app</string>
 				<key>requirement</key>
 				<string>identifier "com.squirrels.Reflection" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "67X2M9MT5G"</string>
 			</dict>

--- a/Sonos/Sonos.download.recipe
+++ b/Sonos/Sonos.download.recipe
@@ -52,7 +52,7 @@
             <key>Arguments</key>
             <dict>
                 <key>input_path</key>
-                <string>%pathname%/%NAME%.app</string>
+                <string>%pathname%/Sonos.app</string>
                 <key>requirement</key>
                 <string>identifier "com.sonos.macController" and anchor apple generic</string>
             </dict>

--- a/Synergy/Synergy.download.recipe
+++ b/Synergy/Synergy.download.recipe
@@ -63,7 +63,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_path</key>
-				<string>%pathname%/%NAME%.app</string>
+				<string>%pathname%/Synergy.app</string>
 				<key>requirement</key>
 				<string>identifier synergy and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "4HX897Y6GJ"</string>
 			</dict>

--- a/WWDC/WWDC.download.recipe
+++ b/WWDC/WWDC.download.recipe
@@ -58,7 +58,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/%NAME%.app</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/WWDC.app</string>
 				<key>requirement</key>
 				<string>anchor apple generic and identifier "io.wwdc.app" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "8C7439RJLG")</string>
 				<key>strict_verification</key>

--- a/WWDC/WWDC.install.recipe
+++ b/WWDC/WWDC.install.recipe
@@ -41,7 +41,7 @@
 						<key>destination_path</key>
 						<string>/Applications</string>
 						<key>source_item</key>
-						<string>%NAME%.app</string>
+						<string>WWDC.app</string>
 					</dict>
 				</array>
 			</dict>

--- a/Workshare/Workshare.download.recipe
+++ b/Workshare/Workshare.download.recipe
@@ -56,7 +56,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_path</key>
-				<string>%pathname%/%NAME%.app</string>
+				<string>%pathname%/Workshare.app</string>
 				<key>requirement</key>
 				<string>identifier "com.workshare.Workshare" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = H2PCB526MT</string>
 			</dict>


### PR DESCRIPTION
Because variables can be overridden, it's a good idea to make sure that the recipe will still work even if a non-default variables used. One issue that would prevent recipes from running is using a `NAME` variable in paths that should be hard-coded (e.g. `/Applications/Foo.app`).

This PR removes the `NAME` variable from all file paths and replaces it with the actual app name, which should make the recipe more resilient for overrides.