### PR TITLE
Basic python3 compatibility

### DIFF
--- a/2016SuiteSKUless/OfficeSuiteSKULessVersionProvider.py
+++ b/2016SuiteSKUless/OfficeSuiteSKULessVersionProvider.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import urllib2
 import xml.etree.ElementTree as ET
 

--- a/2016SuiteSKUless/OfficeSuiteSKULessVersionProvider.py
+++ b/2016SuiteSKUless/OfficeSuiteSKULessVersionProvider.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 from __future__ import absolute_import
+
 import xml.etree.ElementTree as ET
 
 from autopkglib import Processor, ProcessorError

--- a/2016SuiteSKUless/OfficeSuiteSKULessVersionProvider.py
+++ b/2016SuiteSKUless/OfficeSuiteSKULessVersionProvider.py
@@ -45,7 +45,7 @@ class OfficeSuiteSKULessVersionProvider(Processor):
         try:
             raw_xml = urlopen(FEED_URL)
             xml = raw_xml.read()
-        except BaseException as e:
+        except Exception as e:
             raise ProcessorError("Can't download %s: %s" % (FEED_URL, e))
 
         root = ET.fromstring(xml)

--- a/2016SuiteSKUless/OfficeSuiteSKULessVersionProvider.py
+++ b/2016SuiteSKUless/OfficeSuiteSKULessVersionProvider.py
@@ -15,10 +15,14 @@
 # limitations under the License.
 
 from __future__ import absolute_import
-import urllib2
 import xml.etree.ElementTree as ET
 
 from autopkglib import Processor, ProcessorError
+
+try:
+    from urllib.request import urlopen  # For Python 3
+except ImportError:
+    from urllib2 import urlopen  # For Python 2
 
 
 __all__ = ["OfficeSuiteSKULessVersionProvider"]
@@ -34,21 +38,21 @@ class OfficeSuiteSKULessVersionProvider(Processor):
         },
     }
     description = __doc__
-    
+
     def get_version(self, FEED_URL):
         """Parse the macadmins.software/versions.xml feed for the latest O365 version number"""
         try:
-            raw_xml = urllib2.urlopen(FEED_URL)
+            raw_xml = urlopen(FEED_URL)
             xml = raw_xml.read()
         except BaseException as e:
             raise ProcessorError("Can't download %s: %s" % (FEED_URL, e))
-        
+
         root = ET.fromstring(xml)
         latest = root.find('latest')
         for vers in root.iter('latest'):
             version = vers.find('o365').text
         return version
-    
+
     def main(self):
         self.env["version"] = self.get_version(FEED_URL)
         self.output("Found Version Number %s" % self.env["version"])

--- a/MSLync/MSLyncURLandUpdateInfoProvider.py
+++ b/MSLync/MSLyncURLandUpdateInfoProvider.py
@@ -43,7 +43,7 @@ class MSLyncURLandUpdateInfoProvider(Processor):
             "description": ("See "
                 "http://msdn.microsoft.com/en-us/library/ee825488(v=cs.20).aspx"
                 " for a table of CultureCodes Defaults to 0409, which "
-                "corresponds to en-US (English - United States)"), 
+                "corresponds to en-US (English - United States)"),
         },
         "base_url": {
             "required": False,
@@ -61,38 +61,38 @@ class MSLyncURLandUpdateInfoProvider(Processor):
         },
         "pkg_name": {
             "description": "Name of the package within the disk image.",
-        }, 
+        },
         "additional_pkginfo": {
-            "description": 
+            "description":
                 "Some pkginfo fields extracted from the Microsoft metadata.",
         },
         "display_name": {
-            "description": 
+            "description":
                 "The name of the package that includes the version.",
         },
     }
     description = __doc__
-    
+
     def sanityCheckExpectedTriggers(self, item):
         """Raises an exeception if the Trigger Condition or
         Triggers for an update don't match what we expect.
         Protects us if these change in the future."""
         if not item.get("Trigger Condition") == ["and", "Lync"]:
             raise ProcessorError(
-                "Unexpected Trigger Condition in item %s: %s" 
+                "Unexpected Trigger Condition in item %s: %s"
                 % (item["Title"], item["Trigger Condition"]))
         if not "Lync" in item.get("Triggers", {}):
             raise ProcessorError(
                 "Missing expected MCP Trigger in item %s" % item["Title"])
-    
+
     def getRequiresFromUpdateItem(self, item):
         """Attempts to determine what earlier updates are
         required by this update"""
-        
+
         def compare_versions(a, b):
             """Internal comparison function for use with sorting"""
             return cmp(LooseVersion(a), LooseVersion(b))
-        
+
         self.sanityCheckExpectedTriggers(item)
         munki_update_name = self.env.get("munki_update_name", MUNKI_UPDATE_NAME)
         mcp_versions = item.get(
@@ -106,7 +106,7 @@ class MSLyncURLandUpdateInfoProvider(Processor):
             # works with original Office release, so no requires array
             return None
         return ["%s-%s" % (munki_update_name, mcp_versions[0])]
-    
+
     def getInstallsItems(self, item):
         """Attempts to parse the Triggers to create an installs item"""
         self.sanityCheckExpectedTriggers(item)
@@ -124,7 +124,7 @@ class MSLyncURLandUpdateInfoProvider(Processor):
             }
             return [installs_item]
         return None
-    
+
     def getVersion(self, item):
         """Extracts the version of the update item."""
         # currently relies on the item having a title in the format
@@ -134,7 +134,7 @@ class MSLyncURLandUpdateInfoProvider(Processor):
         title = item.get("Title", "")
         version_str = title.replace(TITLE_START, "").replace(TITLE_END, "")
         return version_str
-    
+
     def valueToOSVersionString(self, value):
         """Converts a value to an OS X version number"""
         if isinstance(value, int):
@@ -185,7 +185,7 @@ class MSLyncURLandUpdateInfoProvider(Processor):
             f.close()
         except BaseException as err:
             raise ProcessorError("Can't download %s: %s" % (base_url, err))
-        
+
         metadata = plistlib.readPlistFromString(data)
         if version_str == "latest":
             # Lync 'update' metadata is a list of dicts.
@@ -196,20 +196,20 @@ class MSLyncURLandUpdateInfoProvider(Processor):
         else:
             # we've been told to find a specific version. Unfortunately, the
             # Lync updates metadata items don't have a version attibute.
-            # The version is only in text in the update's Title. So we look for 
+            # The version is only in text in the update's Title. So we look for
             # that...
             # Titles are in the format "Lync x.y.z Update"
             padded_version_str = " " + version_str + " "
-            matched_items = [item for item in metadata 
+            matched_items = [item for item in metadata
                             if padded_version_str in item["Title"]]
             if len(matched_items) != 1:
                 raise ProcessorError(
                     "Could not find version %s in update metadata. "
-                    "Updates that are available: %s" 
-                    % (version_str, ", ".join(["'%s'" % item["Title"] 
+                    "Updates that are available: %s"
+                    % (version_str, ", ".join(["'%s'" % item["Title"]
                                                for item in metadata])))
             item = matched_items[0]
-        
+
         self.env["url"] = item["Location"]
         self.env["pkg_name"] = item["Payload"]
         self.output("Found URL %s" % self.env["url"])
@@ -232,7 +232,7 @@ class MSLyncURLandUpdateInfoProvider(Processor):
         if requires:
             pkginfo["requires"] = requires
             self.output(
-                "Update requires previous update version %s" 
+                "Update requires previous update version %s"
                 % requires[0].split("-")[1])
 
         pkginfo['name'] = self.env.get("munki_update_name", MUNKI_UPDATE_NAME)

--- a/MSLync/MSLyncURLandUpdateInfoProvider.py
+++ b/MSLync/MSLyncURLandUpdateInfoProvider.py
@@ -137,6 +137,12 @@ class MSLyncURLandUpdateInfoProvider(Processor):
 
     def valueToOSVersionString(self, value):
         """Converts a value to an OS X version number"""
+        # Map string type for both Python 2 and Python 3.
+        try:
+            _ = basestring
+        except NameError:
+            basestring = str  # pylint: disable=W0622
+
         if isinstance(value, int):
             version_str = hex(value)[2:]
         elif isinstance(value, basestring):

--- a/MSLync/MSLyncURLandUpdateInfoProvider.py
+++ b/MSLync/MSLyncURLandUpdateInfoProvider.py
@@ -16,14 +16,13 @@
 
 
 from __future__ import absolute_import
+
 import plistlib
 import urllib2
-
 from distutils.version import LooseVersion
 from operator import itemgetter
 
 from autopkglib import Processor, ProcessorError
-
 
 __all__ = ["MSLyncURLandUpdateInfoProvider"]
 

--- a/MSLync/MSLyncURLandUpdateInfoProvider.py
+++ b/MSLync/MSLyncURLandUpdateInfoProvider.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 
+from __future__ import absolute_import
 import plistlib
 import urllib2
 

--- a/MSLync/MSLyncURLandUpdateInfoProvider.py
+++ b/MSLync/MSLyncURLandUpdateInfoProvider.py
@@ -188,7 +188,7 @@ class MSLyncURLandUpdateInfoProvider(Processor):
             f = urllib2.urlopen(req)
             data = f.read()
             f.close()
-        except BaseException as err:
+        except Exception as err:
             raise ProcessorError("Can't download %s: %s" % (base_url, err))
 
         metadata = plistlib.readPlistFromString(data)

--- a/MSMAU/MAUURLandUpdateInfoProvider.py
+++ b/MSMAU/MAUURLandUpdateInfoProvider.py
@@ -139,7 +139,7 @@ class MAUURLandUpdateInfoProvider(Processor):
             f = urllib2.urlopen(req)
             data = f.read()
             f.close()
-        except BaseException as err:
+        except Exception as err:
             raise ProcessorError("Can't download %s: %s" % (base_url, err))
 
         item = plistlib.readPlistFromString(data)[-1]

--- a/MSMAU/MAUURLandUpdateInfoProvider.py
+++ b/MSMAU/MAUURLandUpdateInfoProvider.py
@@ -39,7 +39,7 @@ class MAUURLandUpdateInfoProvider(Processor):
             "description": ("See "
                 "http://msdn.microsoft.com/en-us/library/ee825488(v=cs.20).aspx"
                 " for a table of CultureCodes Defaults to 0409, which "
-                "corresponds to en-US (English - United States)"), 
+                "corresponds to en-US (English - United States)"),
         },
         "base_url": {
             "required": False,
@@ -52,11 +52,11 @@ class MAUURLandUpdateInfoProvider(Processor):
             "description": "URL to the latest MAU installer.",
         },
         "additional_pkginfo": {
-            "description": 
+            "description":
                 "Some pkginfo fields extracted from the Microsoft metadata.",
         },
         "display_name": {
-            "description": 
+            "description":
                 "The name of the package that includes the version.",
         },
         "version": {
@@ -67,7 +67,7 @@ class MAUURLandUpdateInfoProvider(Processor):
 
     def getAppPath(self, item):
         """less hardcoding, finds path to app via feed metadata item"""
-        app_path = item.get("UpdateBaseSearchPath", 
+        app_path = item.get("UpdateBaseSearchPath",
                             "/Library/Application Support/Microsoft/MAU2.0")
         return app_path
 
@@ -82,12 +82,12 @@ class MAUURLandUpdateInfoProvider(Processor):
             "version_comparison_key": "CFBundleShortVersionString"
         }
         return [installs_item]
-    
+
     def getVersion(self, item):
         """Extracts the version of the item."""
         version_str = item.get("Update Version", "")
         return version_str
-    
+
     def valueToOSVersionString(self, value):
         """Converts a value to an OS X version number"""
         if isinstance(value, int):
@@ -133,7 +133,7 @@ class MAUURLandUpdateInfoProvider(Processor):
             f.close()
         except BaseException as err:
             raise ProcessorError("Can't download %s: %s" % (base_url, err))
-        
+
         item = plistlib.readPlistFromString(data)[-1]
 
         self.env["url"] = item["Location"]

--- a/MSMAU/MAUURLandUpdateInfoProvider.py
+++ b/MSMAU/MAUURLandUpdateInfoProvider.py
@@ -90,6 +90,12 @@ class MAUURLandUpdateInfoProvider(Processor):
 
     def valueToOSVersionString(self, value):
         """Converts a value to an OS X version number"""
+        # Map string type for both Python 2 and Python 3.
+        try:
+            _ = basestring
+        except NameError:
+            basestring = str  # pylint: disable=W0622
+
         if isinstance(value, int):
             version_str = hex(value)[2:]
         elif isinstance(value, basestring):

--- a/MSMAU/MAUURLandUpdateInfoProvider.py
+++ b/MSMAU/MAUURLandUpdateInfoProvider.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 
+from __future__ import absolute_import
 import plistlib
 import urllib2
 

--- a/MSMAU/MAUURLandUpdateInfoProvider.py
+++ b/MSMAU/MAUURLandUpdateInfoProvider.py
@@ -16,13 +16,15 @@
 
 
 from __future__ import absolute_import
+
 import plistlib
 import urllib2
+
+from autopkglib import Processor, ProcessorError
 
 # from distutils.version import LooseVersion
 # from operator import itemgetter
 
-from autopkglib import Processor, ProcessorError
 
 
 __all__ = ["MAUURLandUpdateInfoProvider"]

--- a/SharedProcessors/SantaCertSha.py
+++ b/SharedProcessors/SantaCertSha.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 """See docstring for SantaCertSha class"""
 
+from __future__ import absolute_import
 import os
 import subprocess
 

--- a/SharedProcessors/SantaCertSha.py
+++ b/SharedProcessors/SantaCertSha.py
@@ -16,10 +16,11 @@
 """See docstring for SantaCertSha class"""
 
 from __future__ import absolute_import
+
 import os
 import subprocess
-
 from glob import glob
+
 from autopkglib import ProcessorError
 from autopkglib.DmgMounter import DmgMounter
 

--- a/SharedProcessors/SantaUnsignedSha.py
+++ b/SharedProcessors/SantaUnsignedSha.py
@@ -66,7 +66,7 @@ class SantaUnsignedSha(DmgMounter):
             try:
                 with open(path, 'rb') as sha_me:
                     binary_sha = hashlib.sha256(sha_me.read()).hexdigest()
-            except BaseException as error:
+            except Exception as error:
                 raise ProcessorError(
                     "Encoutered error %s getting sha256 from path, %s" % (error, path))
         return binary_sha
@@ -106,7 +106,7 @@ class SantaUnsignedSha(DmgMounter):
                 sha = self.check_and_hash(input_path)
                 self.output("Here's some sha %s" % sha)
                 shas_forwlist.append(sha)
-            except BaseException as error:
+            except Exception as error:
                 raise ProcessorError("Error processing path '%s', '%s'" % (input_path, error))
         if dmg:
             self.unmount(dmg_path)

--- a/SharedProcessors/SantaUnsignedSha.py
+++ b/SharedProcessors/SantaUnsignedSha.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 """See docstring for SantaCertSha class"""
 
+from __future__ import absolute_import
 import hashlib
 import os
 

--- a/SharedProcessors/SantaUnsignedSha.py
+++ b/SharedProcessors/SantaUnsignedSha.py
@@ -65,7 +65,7 @@ class SantaUnsignedSha(DmgMounter):
             try:
                 with open(path, 'rb') as sha_me:
                     binary_sha = hashlib.sha256(sha_me.read()).hexdigest()
-            except Exception as error:
+            except BaseException as error:
                 raise ProcessorError(
                     "Encoutered error %s getting sha256 from path, %s" % (error, path))
         return binary_sha
@@ -105,7 +105,7 @@ class SantaUnsignedSha(DmgMounter):
                 sha = self.check_and_hash(input_path)
                 self.output("Here's some sha %s" % sha)
                 shas_forwlist.append(sha)
-            except Exception as error:
+            except BaseException as error:
                 raise ProcessorError("Error processing path '%s', '%s'" % (input_path, error))
         if dmg:
             self.unmount(dmg_path)

--- a/SharedProcessors/SantaUnsignedSha.py
+++ b/SharedProcessors/SantaUnsignedSha.py
@@ -16,10 +16,11 @@
 """See docstring for SantaCertSha class"""
 
 from __future__ import absolute_import
+
 import hashlib
 import os
-
 from stat import S_IXOTH
+
 from autopkglib import ProcessorError
 from autopkglib.DmgMounter import DmgMounter
 

--- a/SharedProcessors/ShoveStuffInABucket.py
+++ b/SharedProcessors/ShoveStuffInABucket.py
@@ -15,12 +15,18 @@
 # limitations under the License.
 
 from __future__ import absolute_import
+
 import os
 import plistlib
 import subprocess
-import urllib
 
 from autopkglib import Processor, ProcessorError
+
+try:
+    from urllib import request as urllib  # For Python 3
+except ImportError:
+    import urllib  # For Python 2
+
 
 
 __all__ = ["ShoveStuffInABucket"]

--- a/SharedProcessors/ShoveStuffInABucket.py
+++ b/SharedProcessors/ShoveStuffInABucket.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import os
 import plistlib
 import subprocess


### PR DESCRIPTION
In order to make your processors more compatible with AutoPkg running in Python 3, I've applied a few adjustments suggested by `python-modernize`, `pylint --py3k`, and `pylint` in general.

More adjustments may need to be made manually later (including handling HTTP headers and URL quoting), but this should catch the low-hanging fruit right now.

I know some of these processors aren't used any more by you, but I'll let you decide when/whether to actually deprecate them.