### PR TITLE
Remove Charles Proxy Settings file requirement

### DIFF
--- a/CharlesProxy/CharlesProxy.pkg.recipe
+++ b/CharlesProxy/CharlesProxy.pkg.recipe
@@ -76,16 +76,6 @@
 							<key>group</key>
 							<string>admin</string>
 						</dict>
-						<dict>
-							<key>path</key>
-							<string>Applications/Charles.app/Contents/Resources/Charles Proxy Settings</string>
-							<key>user</key>
-							<string>root</string>
-							<key>group</key>
-							<string>admin</string>
-							<key>mode</key>
-							<string>4755</string>
-						</dict>
 					</array>
 				</dict>
 			</dict>


### PR DESCRIPTION
This file is no longer in Charles after version 4.5, and removing this requirement creates a perfectly functional package as far as I can tell.