### PR TITLE
Changing to Static Download URL

### DIFF
--- a/Pacifist/Pacifist.download.recipe
+++ b/Pacifist/Pacifist.download.recipe
@@ -12,20 +12,11 @@
     <dict>
         <key>NAME</key>
         <string>Pacifist</string>
-        <key>SPARKLE_FEED_URL</key>
-        <string>https://www.charlessoft.com/cgi-bin/pacifist_sparkle.cgi</string>
+        <key>DOWNLOAD_URL</key>
+        <string>https://www.charlessoft.com/cgi-bin/pacifist_download.cgi?type=dmg</string>
 	</dict>
     <key>Process</key>
     <array>
-        <dict>
-            <key>Processor</key>
-            <string>SparkleUpdateInfoProvider</string>
-            <key>Arguments</key>
-            <dict>
-                <key>appcast_url</key>
-                <string>%SPARKLE_FEED_URL%</string>
-            </dict>
-        </dict>
         <dict>
             <key>Processor</key>
             <string>URLDownloader</string>
@@ -33,6 +24,8 @@
             <dict>
                 <key>filename</key>
                 <string>%NAME%.dmg</string>
+                <key>url</key>
+                <string>%DOWNLOAD_URL%</string>
             </dict>
         </dict>
         <dict>


### PR DESCRIPTION
Since SparkleUpdateInfoProvider has issues with the current Pacifist feed (retrieves 3.5.1 versus 3.6.2) and there's a static download URL, switching to use a static download URL.