### PR TITLE
Hipchat download missing a tag

### DIFF
--- a/Atlassian/HipChat.download.recipe
+++ b/Atlassian/HipChat.download.recipe
@@ -54,7 +54,7 @@
                 <key>input_path</key>
                 <string>%RECIPE_CACHE_DIR%/downloads/%NAME%.dmg/HipChat.app</string>
                 <key>requirement</key>
-                <string>identifier "com.hipchat.HipChat" and anchor apple generic and certificate leaf[subject.CN] = "Mac Developer: Build Agent (HGAXT6PX93)" and certificate 1[field.1.2.840.113635.100.6.2.1] /* exists */
+                <string>identifier "com.hipchat.HipChat" and anchor apple generic and certificate leaf[subject.CN] = "Mac Developer: Build Agent (HGAXT6PX93)" and certificate 1[field.1.2.840.113635.100.6.2.1] /* exists */</string>
             </dict>
         </dict>
     </array>


### PR DESCRIPTION
>WARNING: plist error for /Volumes/Data/AutoPkg/RecipeRepos/com.github.autopkg.arubdesu-recipes/Atlassian/HipChat.download.recipe: Error Domain=NSCocoaErrorDomain Code=3840 "Close tag on line 58 does not match open tag string" UserInfo={NSDebugDescription=Close tag on line 58 does not match open tag string, kCFPropertyListOldStyleParsingError=Error Domain=NSCocoaErrorDomain Code=3840 "Malformed data byte group at line 1; invalid hex" UserInfo={NSDebugDescription=Malformed data byte group at line 1; invalid hex}}

a close string tag was missing on line 57.