### PR TITLE
Correctly get the Sonos Application name

### DIFF
--- a/Sonos/Sonos.pkg.recipe
+++ b/Sonos/Sonos.pkg.recipe
@@ -46,9 +46,9 @@
 			<key>Arguments</key>
 			<dict>
 				<key>source_path</key>
-				<string>%pathname%/Sonos.app</string>
+				<string>%pathname%/%app_name%</string>
 				<key>destination_path</key>
-				<string>%pkgroot%/Applications/Sonos.app</string>
+				<string>%pkgroot%/Applications/%app_name%</string>
 			</dict>
 		</dict>
 		<dict>


### PR DESCRIPTION
With Sonos switching to naming their app from `Sonos.app` to 
`Sonos S1 Controller` the pkg was not successfully being created due to the name
change. This commit pulls the `app_name` from the `AppDmgVersioner`
process and uses that in place of `Sonos.app`.