### PR TITLE
Remove unused BUNDLE_ID input var

### DIFF
--- a/8x8Inc/8x8Work.pkg.recipe
+++ b/8x8Inc/8x8Work.pkg.recipe
@@ -10,8 +10,6 @@
 	<string>com.github.arubdesu.pkg.8x8Work</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>com.electron.8x8---virtual-office</string>
 		<key>NAME</key>
 		<string>8x8 - Virtual Office</string>
 	</dict>

--- a/JetBrainsToolbox/JetBrainsToolbox.pkg.recipe
+++ b/JetBrainsToolbox/JetBrainsToolbox.pkg.recipe
@@ -10,8 +10,6 @@
 	<string>com.github.autopkg.arubdesu-recipes.pkg.JetBrainsToolbox</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>com.jetbrains.apps.activator</string>
 		<key>NAME</key>
 		<string>JetBrains Toolbox</string>
 	</dict>


### PR DESCRIPTION
This pull request removes unused instances of `BUNDLE_ID` from recipe input variables, which will help reduce confusion by new AutoPkg users and simplify overrides created from this point on.

Making `BUNDLE_ID` available as an input variable is a common practice in AutoPkg recipes that use the [PkgCreator](https://github.com/autopkg/autopkg/wiki/Processor-PkgCreator) processor ([example](https://github.com/autopkg/homebysix-recipes/blob/4fec9244a3af0f9b7c8f61f35a5cd7f4622fb162/soma-zone/LaunchControl.pkg.recipe#L40-L41)). It's likely that these recipes transitioned from PkgCreator to the more streamlined [AppPkgCreator](https://github.com/autopkg/autopkg/wiki/Processor-AppPkgCreator) processor some time ago, but the now-unused input variable for `BUNDLE_ID` was never removed.

Recipe run output is included below for all changed recipes (excluding jss and install recipe types). Any run failures are very likely to be unrelated to this change.

## ✅ 8x8Inc/8x8Work.pkg.recipe

```
% /usr/local/bin/autopkg run -vvq repos/arubdesu-recipes/8x8Inc/8x8Work.pkg.recipe
Processing repos/arubdesu-recipes/8x8Inc/8x8Work.pkg.recipe...
URLTextSearcher
{'Input': {'re_pattern': 'href="(https://vod-updates.8x8.com/ga/work-dmg-.*.dmg)"',
           'url': 'https://support.8x8.com/cloud-phone-service/voice/work-desktop/download-8x8-work-for-desktop'}}
URLTextSearcher: No value supplied for result_output_var_name, setting default value of: match
URLTextSearcher: Found matching text (match): https://vod-updates.8x8.com/ga/work-dmg-v7.4.3-5.dmg
{'Output': {'match': 'https://vod-updates.8x8.com/ga/work-dmg-v7.4.3-5.dmg'}}
URLDownloader
{'Input': {'filename': '8x8 - Virtual Office.dmg',
           'url': 'https://vod-updates.8x8.com/ga/work-dmg-v7.4.3-5.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.arubdesu.pkg.8x8Work/downloads/8x8 - Virtual Office.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.arubdesu.pkg.8x8Work/downloads/8x8 '
                        '- Virtual Office.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.arubdesu.pkg.8x8Work/downloads/8x8 '
                         '- Virtual Office.dmg/8x8 Work.app',
           'requirement': 'identifier "com.electron.8x8---virtual-office" and '
                          'anchor apple generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          'FC967L3QRG'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.arubdesu.pkg.8x8Work/downloads/8x8 - Virtual Office.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.5dk6ZC/8x8 Work.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.5dk6ZC/8x8 Work.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.5dk6ZC/8x8 Work.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Versioner
{'Input': {'input_plist_path': '~/Library/AutoPkg/Cache/com.github.arubdesu.pkg.8x8Work/downloads/8x8 '
                               '- Virtual Office.dmg/8x8 '
                               'Work.app/Contents/Info.plist',
           'plist_version_key': 'CFBundleVersion'}}
Versioner: Mounted disk image ~/Library/AutoPkg/Cache/com.github.arubdesu.pkg.8x8Work/downloads/8x8 - Virtual Office.dmg
Versioner: Found version 7.4.3.5 in file /private/tmp/dmg.PtH2W2/8x8 Work.app/Contents/Info.plist
{'Output': {'version': '7.4.3.5'}}
AppPkgCreator
{'Input': {'version': '7.4.3.5'}}
AppPkgCreator: Mounted disk image ~/Library/AutoPkg/Cache/com.github.arubdesu.pkg.8x8Work/downloads/8x8 - Virtual Office.dmg
AppPkgCreator: Using path '/private/tmp/dmg.WFORC7/8x8 Work.app' matched from globbed '/private/tmp/dmg.WFORC7/*.app'.
AppPkgCreator: BundleID: com.electron.8x8---virtual-office
AppPkgCreator: Copied /private/tmp/dmg.WFORC7/8x8 Work.app to ~/Library/AutoPkg/Cache/com.github.arubdesu.pkg.8x8Work/payload/Applications/8x8 Work.app
AppPkgCreator: Connecting
AppPkgCreator: Sending packaging request
AppPkgCreator: Disconnecting
AppPkgCreator: Failed to close socket: [Errno 9] Bad file descriptor
{'Output': {'app_pkg_creator_summary_result': {'data': {'identifier': 'com.electron.8x8---virtual-office',
                                                        'pkg_path': '~/Library/AutoPkg/Cache/com.github.arubdesu.pkg.8x8Work/8x8 '
                                                                    'Work-7.4.3.5.pkg',
                                                        'version': '7.4.3.5'},
                                               'report_fields': ['identifier',
                                                                 'version',
                                                                 'pkg_path'],
                                               'summary_text': 'The following '
                                                               'packages were '
                                                               'built:'},
            'new_package_request': True,
            'version': '7.4.3.5'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.arubdesu.pkg.8x8Work/receipts/8x8Work.pkg-receipt-20210213-221845.plist

The following packages were built:
    Identifier                         Version  Pkg Path                                                                                   
    ----------                         -------  --------                                                                                   
    com.electron.8x8---virtual-office  7.4.3.5  ~/Library/AutoPkg/Cache/com.github.arubdesu.pkg.8x8Work/8x8 Work-7.4.3.5.pkg  
```

## ✅ JetBrainsToolbox/JetBrainsToolbox.pkg.recipe

```
% /usr/local/bin/autopkg run -vvq repos/arubdesu-recipes/JetBrainsToolbox/JetBrainsToolbox.pkg.recipe
Processing repos/arubdesu-recipes/JetBrainsToolbox/JetBrainsToolbox.pkg.recipe...
URLTextSearcher
{'Input': {'re_pattern': 'mac":{"link":"(.+?dmg)"',
           'url': 'https://data.services.jetbrains.com/products/releases?code=TBA'}}
URLTextSearcher: No value supplied for result_output_var_name, setting default value of: match
URLTextSearcher: Found matching text (match): https://download.jetbrains.com/toolbox/jetbrains-toolbox-1.20.7940.dmg
{'Output': {'match': 'https://download.jetbrains.com/toolbox/jetbrains-toolbox-1.20.7940.dmg'}}
URLDownloader
{'Input': {'filename': 'JetBrains Toolbox.dmg',
           'url': 'https://download.jetbrains.com/toolbox/jetbrains-toolbox-1.20.7940.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.autopkg.arubdesu-recipes.pkg.JetBrainsToolbox/downloads/JetBrains Toolbox.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.autopkg.arubdesu-recipes.pkg.JetBrainsToolbox/downloads/JetBrains '
                        'Toolbox.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.autopkg.arubdesu-recipes.pkg.JetBrainsToolbox/downloads/JetBrains '
                         'Toolbox.dmg/JetBrains Toolbox.app',
           'requirement': 'identifier "com.jetbrains.toolbox" and anchor apple '
                          'generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          '"2ZEFAR8TH3"'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.autopkg.arubdesu-recipes.pkg.JetBrainsToolbox/downloads/JetBrains Toolbox.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.95agGR/JetBrains Toolbox.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.95agGR/JetBrains Toolbox.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.95agGR/JetBrains Toolbox.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Versioner
{'Input': {'input_plist_path': '~/Library/AutoPkg/Cache/com.github.autopkg.arubdesu-recipes.pkg.JetBrainsToolbox/downloads/JetBrains '
                               'Toolbox.dmg/JetBrains '
                               'Toolbox.app/Contents/Info.plist',
           'plist_version_key': 'CFBundleShortVersionString'}}
Versioner: Mounted disk image ~/Library/AutoPkg/Cache/com.github.autopkg.arubdesu-recipes.pkg.JetBrainsToolbox/downloads/JetBrains Toolbox.dmg
Versioner: Found version 1.20.7940 in file /private/tmp/dmg.wATiDS/JetBrains Toolbox.app/Contents/Info.plist
{'Output': {'version': '1.20.7940'}}
AppPkgCreator
{'Input': {'version': '1.20.7940'}}
AppPkgCreator: Mounted disk image ~/Library/AutoPkg/Cache/com.github.autopkg.arubdesu-recipes.pkg.JetBrainsToolbox/downloads/JetBrains Toolbox.dmg
AppPkgCreator: Using path '/private/tmp/dmg.UW0glp/JetBrains Toolbox.app' matched from globbed '/private/tmp/dmg.UW0glp/*.app'.
AppPkgCreator: BundleID: com.jetbrains.toolbox
AppPkgCreator: Copied /private/tmp/dmg.UW0glp/JetBrains Toolbox.app to ~/Library/AutoPkg/Cache/com.github.autopkg.arubdesu-recipes.pkg.JetBrainsToolbox/payload/Applications/JetBrains Toolbox.app
AppPkgCreator: Connecting
AppPkgCreator: Sending packaging request
AppPkgCreator: Disconnecting
AppPkgCreator: Failed to close socket: [Errno 9] Bad file descriptor
{'Output': {'app_pkg_creator_summary_result': {'data': {'identifier': 'com.jetbrains.toolbox',
                                                        'pkg_path': '~/Library/AutoPkg/Cache/com.github.autopkg.arubdesu-recipes.pkg.JetBrainsToolbox/JetBrains '
                                                                    'Toolbox-1.20.7940.pkg',
                                                        'version': '1.20.7940'},
                                               'report_fields': ['identifier',
                                                                 'version',
                                                                 'pkg_path'],
                                               'summary_text': 'The following '
                                                               'packages were '
                                                               'built:'},
            'new_package_request': True,
            'version': '1.20.7940'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.autopkg.arubdesu-recipes.pkg.JetBrainsToolbox/receipts/JetBrainsToolbox.pkg-receipt-20210213-221919.plist

The following packages were built:
    Identifier             Version    Pkg Path                                                                                                                       
    ----------             -------    --------                                                                                                                       
    com.jetbrains.toolbox  1.20.7940  ~/Library/AutoPkg/Cache/com.github.autopkg.arubdesu-recipes.pkg.JetBrainsToolbox/JetBrains Toolbox-1.20.7940.pkg  
```

