### PR TITLE
Updated 8x8 recipes to reflect separate download links for Intel and ARM64 architecture

### DIFF
--- a/8x8Inc/8x8Work-Intel.download.recipe
+++ b/8x8Inc/8x8Work-Intel.download.recipe
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Description</key>
+	<string>Downloads the latest Intel (x64) version of 8x8 Work</string>
+	<key>Identifier</key>
+	<string>com.github.arubdesu.download.8x8Work</string>
+	<key>Input</key>
+	<dict>
+		<key>NAME</key>
+		<string>8x8Work</string>
+	</dict>
+	<key>MinimumVersion</key>
+	<string>1.0.0</string>
+	<key>Process</key>
+	<array>
+		<dict>
+			<key>Processor</key>
+			<string>URLTextSearcher</string>
+			<key>Arguments</key>
+			<dict>
+				<key>url</key>
+				<string>https://support.8x8.com/cloud-phone-service/voice/work-desktop/download-8x8-work-for-desktop</string>
+				<key>re_pattern</key>
+				<string>href="(https://vod-updates.8x8.com/ga/work-dmg-.*.dmg)"</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>Processor</key>
+			<string>URLDownloader</string>
+			<key>Arguments</key>
+			<dict>
+				<key>url</key>
+				<string>%match%</string>
+				<key>filename</key>
+				<string>%NAME%.dmg</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>Processor</key>
+			<string>EndOfCheckPhase</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>input_path</key>
+				<string>%pathname%/8x8 Work.app</string>
+				<key>requirement</key>
+				<string>identifier "com.electron.8x8---virtual-office" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = FC967L3QRG</string>
+			</dict>
+			<key>Processor</key>
+			<string>CodeSignatureVerifier</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>input_plist_path</key>
+				<string>%pathname%/8x8 Work.app/Contents/Info.plist</string>
+				<key>plist_version_key</key>
+				<string>CFBundleVersion</string>
+			</dict>
+			<key>Processor</key>
+			<string>Versioner</string>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/8x8Inc/8x8Work.download.recipe
+++ b/8x8Inc/8x8Work.download.recipe
@@ -12,8 +12,6 @@
 	<dict>
 		<key>NAME</key>
 		<string>8x8Work</string>
-		<key>ARCH</key>
-		<string>arm64</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>1.0.0</string>
@@ -27,7 +25,7 @@
 				<key>url</key>
 				<string>https://support.8x8.com/cloud-phone-service/voice/work-desktop/download-8x8-work-for-desktop</string>
 				<key>re_pattern</key>
-				<string>href="(https://vod-updates.8x8.com/ga/work-%ARCH%\-dmg-.*.dmg)"</string>
+				<string>href="(https://vod-updates.8x8.com/ga/work-arm64-dmg-.*.dmg)"</string>
 			</dict>
 		</dict>
 		<dict>

--- a/8x8Inc/8x8Work.download.recipe
+++ b/8x8Inc/8x8Work.download.recipe
@@ -5,7 +5,7 @@
 	<key>Comment</key>
 	<string>Originally created with Recipe Robot (https://github.com/homebysix/recipe-robot)</string>
 	<key>Description</key>
-	<string>Downloads the latest version of 8x8 Work</string>
+	<string>Downloads the latest arm64 version of 8x8 Work</string>
 	<key>Identifier</key>
 	<string>com.github.arubdesu.download.8x8Work</string>
 	<key>Input</key>

--- a/8x8Inc/8x8Work.download.recipe
+++ b/8x8Inc/8x8Work.download.recipe
@@ -12,6 +12,8 @@
 	<dict>
 		<key>NAME</key>
 		<string>8x8Work</string>
+		<key>ARCH</key>
+		<string>arm64</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>1.0.0</string>
@@ -25,7 +27,7 @@
 				<key>url</key>
 				<string>https://support.8x8.com/cloud-phone-service/voice/work-desktop/download-8x8-work-for-desktop</string>
 				<key>re_pattern</key>
-				<string>href="(https://vod-updates.8x8.com/ga/work-dmg-.*.dmg)"</string>
+				<string>href="(https://vod-updates.8x8.com/ga/work-%ARCH%\-dmg-.*.dmg)"</string>
 			</dict>
 		</dict>
 		<dict>


### PR DESCRIPTION
8x8 has 2 separate downloads, one for Intel and one for arm64. Because of the changes in naming convention it is no longer sanitary to use the same download recipe for both versions. This one is defaulted to arm64 as that will be the most common download in future and the new recipe will be created for Intel architecture.