### PR TITLE
Update OrbStack.download.recipe

### DIFF
--- a/OrbStack/OrbStack.download.recipe
+++ b/OrbStack/OrbStack.download.recipe
@@ -5,13 +5,20 @@
 	<key>Comment</key>
 	<string>Created with Recipe Robot v2.3.1 (https://github.com/homebysix/recipe-robot)</string>
 	<key>Description</key>
-	<string>Downloads the latest (Apple Silicon-specific) version of OrbStack.</string>
+	<string>Downloads the latest version of OrbStack.
+
+For Intel use: "amd64" in the DOWNLOAD_ARCH variable
+For Apple Silicon use: "arm64" in the DOWNLOAD_ARCH variable
+
+Defaults to Apple Silicon</string>
 	<key>Identifier</key>
 	<string>com.github.arubdesu.download.OrbStack</string>
 	<key>Input</key>
 	<dict>
 		<key>NAME</key>
 		<string>OrbStack</string>
+		<key>DOWNLOAD_ARCH</key>
+		<string>arm64</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>2.3</string>
@@ -23,7 +30,7 @@
 				<key>filename</key>
 				<string>%NAME%.dmg</string>
 				<key>url</key>
-				<string>https://orbstack.dev/download/stable/latest/arm64</string>
+				<string>https://orbstack.dev/download/stable/latest/%DOWNLOAD_ARCH%</string>
 			</dict>
 			<key>Processor</key>
 			<string>URLDownloader</string>


### PR DESCRIPTION
Hi, @arubdesu 

This PR adds support for downloading the intel version via a `DOWNLOAD_ARCH` variable. 

I've set variable to be `arm64` so as not to change the original default behaviour of this recipe. 

Thanks! 

Output from a successful  Intel run 
```
autopkg run -vv OrbStack.download.recipe
**load_recipe time: 0.0003440839936956763
Processing OrbStack.download.recipe...
WARNING: OrbStack.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLDownloader
{'Input': {'filename': 'OrbStack.dmg',
           'url': 'https://orbstack.dev/download/stable/latest/amd64'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Wed, 14 Feb 2024 06:23:07 GMT
URLDownloader: Storing new ETag header: "eae219156eff46742460320ed873843b-56"
URLDownloader: Downloaded /Users/paul.cossey/Library/AutoPkg/Cache/com.github.arubdesu.download.OrbStack/downloads/OrbStack.dmg
{'Output': {'download_changed': True,
            'etag': '"eae219156eff46742460320ed873843b-56"',
            'last_modified': 'Wed, 14 Feb 2024 06:23:07 GMT',
            'pathname': '/Users/paul.cossey/Library/AutoPkg/Cache/com.github.arubdesu.download.OrbStack/downloads/OrbStack.dmg',
            'url_downloader_summary_result': {'data': {'download_path': '/Users/paul.cossey/Library/AutoPkg/Cache/com.github.arubdesu.download.OrbStack/downloads/OrbStack.dmg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '/Users/paul.cossey/Library/AutoPkg/Cache/com.github.arubdesu.download.OrbStack/downloads/OrbStack.dmg/OrbStack.app',
           'requirement': 'anchor apple generic and identifier '
                          '"dev.kdrag0n.MacVirt" and (certificate '
                          'leaf[field.1.2.840.113635.100.6.1.9] /* exists */ '
                          'or certificate 1[field.1.2.840.113635.100.6.2.6] /* '
                          'exists */ and certificate '
                          'leaf[field.1.2.840.113635.100.6.1.13] /* exists */ '
                          'and certificate leaf[subject.OU] = HUAQ24HBR6)'}}
CodeSignatureVerifier: Mounted disk image /Users/paul.cossey/Library/AutoPkg/Cache/com.github.arubdesu.download.OrbStack/downloads/OrbStack.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.C0PKaw/OrbStack.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.C0PKaw/OrbStack.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.C0PKaw/OrbStack.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Versioner
{'Input': {'input_plist_path': '/Users/paul.cossey/Library/AutoPkg/Cache/com.github.arubdesu.download.OrbStack/downloads/OrbStack.dmg/OrbStack.app/Contents/Info.plist',
           'plist_version_key': 'CFBundleShortVersionString'}}
Versioner: No value supplied for skip_single_root_dir, setting default value of: False
Versioner: Mounted disk image /Users/paul.cossey/Library/AutoPkg/Cache/com.github.arubdesu.download.OrbStack/downloads/OrbStack.dmg
Versioner: Found version 1.4.3 in file /Users/paul.cossey/Library/AutoPkg/Cache/com.github.arubdesu.download.OrbStack/downloads/OrbStack.dmg/OrbStack.app/Contents/Info.plist
{'Output': {'version': '1.4.3'}}
Receipt written to /Users/paul.cossey/Library/AutoPkg/Cache/com.github.arubdesu.download.OrbStack/receipts/OrbStack.download-receipt-20240214-125301.plist

The following new items were downloaded:
    Download Path                                                                                          
    -------------                                                                                          
    /Users/paul.cossey/Library/AutoPkg/Cache/com.github.arubdesu.download.OrbStack/downloads/OrbStack.dmg 
```

Out[put from a successful Apple Silicon run
```
autopkg run -vv OrbStack.download.recipe
**load_recipe time: 0.0003138750034850091
Processing OrbStack.download.recipe...
WARNING: OrbStack.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLDownloader
{'Input': {'filename': 'OrbStack.dmg',
           'url': 'https://orbstack.dev/download/stable/latest/arm64'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Wed, 14 Feb 2024 06:23:05 GMT
URLDownloader: Storing new ETag header: "daa7c1d4c045a04fce36f0f02942c032-50"
URLDownloader: Downloaded /Users/paul.cossey/Library/AutoPkg/Cache/com.github.arubdesu.download.OrbStack/downloads/OrbStack.dmg
{'Output': {'download_changed': True,
            'etag': '"daa7c1d4c045a04fce36f0f02942c032-50"',
            'last_modified': 'Wed, 14 Feb 2024 06:23:05 GMT',
            'pathname': '/Users/paul.cossey/Library/AutoPkg/Cache/com.github.arubdesu.download.OrbStack/downloads/OrbStack.dmg',
            'url_downloader_summary_result': {'data': {'download_path': '/Users/paul.cossey/Library/AutoPkg/Cache/com.github.arubdesu.download.OrbStack/downloads/OrbStack.dmg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '/Users/paul.cossey/Library/AutoPkg/Cache/com.github.arubdesu.download.OrbStack/downloads/OrbStack.dmg/OrbStack.app',
           'requirement': 'anchor apple generic and identifier '
                          '"dev.kdrag0n.MacVirt" and (certificate '
                          'leaf[field.1.2.840.113635.100.6.1.9] /* exists */ '
                          'or certificate 1[field.1.2.840.113635.100.6.2.6] /* '
                          'exists */ and certificate '
                          'leaf[field.1.2.840.113635.100.6.1.13] /* exists */ '
                          'and certificate leaf[subject.OU] = HUAQ24HBR6)'}}
CodeSignatureVerifier: Mounted disk image /Users/paul.cossey/Library/AutoPkg/Cache/com.github.arubdesu.download.OrbStack/downloads/OrbStack.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.zKV90I/OrbStack.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.zKV90I/OrbStack.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.zKV90I/OrbStack.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Versioner
{'Input': {'input_plist_path': '/Users/paul.cossey/Library/AutoPkg/Cache/com.github.arubdesu.download.OrbStack/downloads/OrbStack.dmg/OrbStack.app/Contents/Info.plist',
           'plist_version_key': 'CFBundleShortVersionString'}}
Versioner: No value supplied for skip_single_root_dir, setting default value of: False
Versioner: Mounted disk image /Users/paul.cossey/Library/AutoPkg/Cache/com.github.arubdesu.download.OrbStack/downloads/OrbStack.dmg
Versioner: Found version 1.4.3 in file /Users/paul.cossey/Library/AutoPkg/Cache/com.github.arubdesu.download.OrbStack/downloads/OrbStack.dmg/OrbStack.app/Contents/Info.plist
{'Output': {'version': '1.4.3'}}
Receipt written to /Users/paul.cossey/Library/AutoPkg/Cache/com.github.arubdesu.download.OrbStack/receipts/OrbStack.download-receipt-20240214-125331.plist

The following new items were downloaded:
    Download Path                                                                                          
    -------------                                                                                          
    /Users/paul.cossey/Library/AutoPkg/Cache/com.github.arubdesu.download.OrbStack/downloads/OrbStack.dmg
```