### PR TITLE
Add 8x8Work-Intel.munki.recipe 

### DIFF
--- a/8x8Inc/8x8Work-Intel.munki.recipe
+++ b/8x8Inc/8x8Work-Intel.munki.recipe
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Comment</key>
+	<string>Originally created with Recipe Robot (https://github.com/homebysix/recipe-robot)</string>
+	<key>Description</key>
+	<string>Downloads the latest version of 8x8 Work and imports it into Munki.</string>
+	<key>Identifier</key>
+	<string>com.github.arubdesu.munki.8x8Work-Intel</string>
+	<key>Input</key>
+	<dict>
+		<key>MUNKI_REPO_SUBDIR</key>
+		<string>apps/%NAME%</string>
+		<key>NAME</key>
+		<string>8x8Work</string>
+		<key>pkginfo</key>
+		<dict>
+			<key>catalogs</key>
+			<array>
+				<string>testing</string>
+			</array>
+			<key>description</key>
+			<string>8x8 Work is a comprehensive unified communications application that integrates a business softphone with visual voicemail, corporate directory, instant messaging, presence, video calling, fax, call recording, and web conferencing—all in a standalone desktop application. Use your Mac or smartphone to make calls, join video conferences or online meetings, chat, manage voicemails, access your company directory, and more.</string>
+			<key>developer</key>
+			<string>8x8, Inc.</string>
+			<key>display_name</key>
+			<string>8x8 Work</string>
+			<key>name</key>
+			<string>%NAME%</string>
+			<key>unattended_install</key>
+			<true/>
+		</dict>
+	</dict>
+	<key>MinimumVersion</key>
+	<string>1.0.0</string>
+	<key>ParentRecipe</key>
+	<string>com.github.arubdesu.download.8x8Work-Intel</string>
+	<key>Process</key>
+	<array>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>pkg_path</key>
+				<string>%pathname%</string>
+				<key>repo_subdirectory</key>
+				<string>%MUNKI_REPO_SUBDIR%</string>
+			</dict>
+			<key>Processor</key>
+			<string>MunkiImporter</string>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/OrbStack/OrbStack.download.recipe
+++ b/OrbStack/OrbStack.download.recipe
@@ -5,13 +5,20 @@
 	<key>Comment</key>
 	<string>Created with Recipe Robot v2.3.1 (https://github.com/homebysix/recipe-robot)</string>
 	<key>Description</key>
-	<string>Downloads the latest (Apple Silicon-specific) version of OrbStack.</string>
+	<string>Downloads the latest version of OrbStack.
+
+For Intel use: "amd64" in the DOWNLOAD_ARCH variable
+For Apple Silicon use: "arm64" in the DOWNLOAD_ARCH variable
+
+Defaults to Apple Silicon</string>
 	<key>Identifier</key>
 	<string>com.github.arubdesu.download.OrbStack</string>
 	<key>Input</key>
 	<dict>
 		<key>NAME</key>
 		<string>OrbStack</string>
+		<key>DOWNLOAD_ARCH</key>
+		<string>arm64</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>2.3</string>
@@ -23,7 +30,7 @@
 				<key>filename</key>
 				<string>%NAME%.dmg</string>
 				<key>url</key>
-				<string>https://orbstack.dev/download/stable/latest/arm64</string>
+				<string>https://orbstack.dev/download/stable/latest/%DOWNLOAD_ARCH%</string>
 			</dict>
 			<key>Processor</key>
 			<string>URLDownloader</string>


### PR DESCRIPTION
Hi, @arubdesu 

This PR adds a Munki recipe for 8x8Work-Intel

Thanks!

Output from a -v run 
```
autopkg run -v 8x8Work-Intel.munki.recipe 
Looking for com.github.arubdesu.download.8x8Work-Intel...
Did not find com.github.arubdesu.download.8x8Work-Intel in recipe map
Rebuilding recipe map with current working directories...
Looking for com.github.arubdesu.download.8x8Work-Intel...
Found com.github.arubdesu.download.8x8Work-Intel in recipe map
**load_recipe time: 0.0056987090210895985
Processing 8x8Work-Intel.munki.recipe...
WARNING: 8x8Work-Intel.munki.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
URLTextSearcher: Found matching text (match): https://vod-updates.8x8.com/ga/work-dmg-v8.11.3-2.dmg
URLDownloader
URLDownloader: Storing new Last-Modified header: Fri, 05 Apr 2024 14:03:43 GMT
URLDownloader: Storing new ETag header: "63871d2bb53d00c37ff53cac9ef291c4-37"
URLDownloader: Downloaded /Users/paul.cossey/Library/AutoPkg/Cache/com.github.arubdesu.munki.8x8Work-Intel/downloads/8x8Work.dmg
EndOfCheckPhase
CodeSignatureVerifier
CodeSignatureVerifier: Mounted disk image /Users/paul.cossey/Library/AutoPkg/Cache/com.github.arubdesu.munki.8x8Work-Intel/downloads/8x8Work.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.SmZYBQ/8x8 Work.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.SmZYBQ/8x8 Work.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.SmZYBQ/8x8 Work.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
Versioner
Versioner: Mounted disk image /Users/paul.cossey/Library/AutoPkg/Cache/com.github.arubdesu.munki.8x8Work-Intel/downloads/8x8Work.dmg
Versioner: Found version 8.11.3.2 in file /Users/paul.cossey/Library/AutoPkg/Cache/com.github.arubdesu.munki.8x8Work-Intel/downloads/8x8Work.dmg/8x8 Work.app/Contents/Info.plist
MunkiImporter
MunkiImporter: Using repo lib: AutoPkgLib
MunkiImporter:         plugin: FileRepo
MunkiImporter:           repo: /Users/Shared/munki_repo
MunkiImporter: Copied pkginfo to: /Users/Shared/munki_repo/pkgsinfo/apps/8x8Work/8x8Work-8.11.3__1.plist
MunkiImporter:            pkg to: /Users/Shared/munki_repo/pkgs/apps/8x8Work/8x8Work-8.11.3__1.dmg
Receipt written to /Users/paul.cossey/Library/AutoPkg/Cache/com.github.arubdesu.munki.8x8Work-Intel/receipts/8x8Work-Intel.munki-receipt-20240417-170317.plist

The following new items were downloaded:
    Download Path                                                                                           
    -------------                                                                                           
    /Users/paul.cossey/Library/AutoPkg/Cache/com.github.arubdesu.munki.8x8Work-Intel/downloads/8x8Work.dmg  

The following new items were imported into Munki:
    Name     Version  Catalogs  Pkginfo Path                          Pkg Repo Path                       Icon Repo Path  
    ----     -------  --------  ------------                          -------------                       --------------  
    8x8Work  8.11.3   testing   apps/8x8Work/8x8Work-8.11.3__1.plist  apps/8x8Work/8x8Work-8.11.3__1.dmg 
```