### PR TITLE
Update OrbStack recipes

### DIFF
--- a/OrbStack/OrbStack.download.recipe
+++ b/OrbStack/OrbStack.download.recipe
@@ -7,18 +7,16 @@
 	<key>Description</key>
 	<string>Downloads the latest version of OrbStack.
 
-For Intel use: "amd64" in the DOWNLOAD_ARCH variable
-For Apple Silicon use: "arm64" in the DOWNLOAD_ARCH variable
-
-Defaults to Apple Silicon</string>
+For Apple Silicon use: "arm64" in the ARCH variable (default)
+For Intel use: "amd64" in the ARCH variable</string>
 	<key>Identifier</key>
 	<string>com.github.arubdesu.download.OrbStack</string>
 	<key>Input</key>
 	<dict>
+		<key>ARCH</key>
+		<string>arm64</string>
 		<key>NAME</key>
 		<string>OrbStack</string>
-		<key>DOWNLOAD_ARCH</key>
-		<string>arm64</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>2.3</string>
@@ -28,9 +26,9 @@ Defaults to Apple Silicon</string>
 			<key>Arguments</key>
 			<dict>
 				<key>filename</key>
-				<string>%NAME%.dmg</string>
+				<string>%NAME%-%ARCH%.dmg</string>
 				<key>url</key>
-				<string>https://orbstack.dev/download/stable/latest/%DOWNLOAD_ARCH%</string>
+				<string>https://orbstack.dev/download/stable/latest/%ARCH%</string>
 			</dict>
 			<key>Processor</key>
 			<string>URLDownloader</string>

--- a/OrbStack/OrbStack.install.recipe
+++ b/OrbStack/OrbStack.install.recipe
@@ -5,11 +5,16 @@
 	<key>Comment</key>
 	<string>Created with Recipe Robot v2.3.1 (https://github.com/homebysix/recipe-robot)</string>
 	<key>Description</key>
-	<string>Installs the latest version of OrbStack.</string>
+	<string>Installs the latest version of OrbStack.
+
+For Apple Silicon use: "arm64" in the ARCH variable (default)
+For Intel use: "amd64" in the ARCH variable</string>
 	<key>Identifier</key>
 	<string>com.github.arubdesu.install.OrbStack</string>
 	<key>Input</key>
 	<dict>
+		<key>ARCH</key>
+		<string>arm64</string>
 		<key>NAME</key>
 		<string>OrbStack</string>
 	</dict>

--- a/OrbStack/OrbStack.munki.recipe
+++ b/OrbStack/OrbStack.munki.recipe
@@ -5,11 +5,16 @@
 	<key>Comment</key>
 	<string>Created with Recipe Robot v2.3.1 (https://github.com/homebysix/recipe-robot)</string>
 	<key>Description</key>
-	<string>Downloads the latest version of OrbStack and imports it into Munki.</string>
+	<string>Downloads the latest version of OrbStack and imports it into Munki.
+
+For Apple Silicon use: "arm64" in the ARCH variable (default)
+For Intel use: "amd64" in the ARCH variable</string>
 	<key>Identifier</key>
 	<string>com.github.arubdesu.munki.OrbStack</string>
 	<key>Input</key>
 	<dict>
+		<key>ARCH</key>
+		<string>arm64</string>
 		<key>MUNKI_REPO_SUBDIR</key>
 		<string>apps/%NAME%</string>
 		<key>NAME</key>
@@ -20,15 +25,19 @@
 			<array>
 				<string>testing</string>
 			</array>
+			<key>category</key>
+			<string>Development</string>
 			<key>description</key>
 			<string>OrbStack is a fast, light, and simple way to run containers and Linux machines on macOS. It's a supercharged alternative to Docker Desktop and WSL, all in one easy-to-use app.</string>
 			<key>developer</key>
-			<string>Orbital Labs, LLC (U.S.)</string>
+			<string>Orbital Labs, LLC</string>
 			<key>display_name</key>
 			<string>OrbStack</string>
 			<key>name</key>
 			<string>%NAME%</string>
 			<key>unattended_install</key>
+			<true/>
+			<key>unattended_uninstall</key>
 			<true/>
 		</dict>
 	</dict>
@@ -38,6 +47,33 @@
 	<string>com.github.arubdesu.download.OrbStack</string>
 	<key>Process</key>
 	<array>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>find</key>
+				<string>amd64</string>
+				<key>input_string</key>
+				<string>%ARCH%</string>
+				<key>replace</key>
+				<string>x86_64</string>
+			</dict>
+			<key>Processor</key>
+			<string>com.github.homebysix.FindAndReplace/FindAndReplace</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>additional_pkginfo</key>
+				<dict>
+					<key>supported_architectures</key>
+					<array>
+						<string>%output_string%</string>
+					</array>
+				</dict>
+			</dict>
+			<key>Processor</key>
+			<string>MunkiPkginfoMerger</string>
+		</dict>
 		<dict>
 			<key>Arguments</key>
 			<dict>

--- a/OrbStack/OrbStack.pkg.recipe
+++ b/OrbStack/OrbStack.pkg.recipe
@@ -5,11 +5,16 @@
 	<key>Comment</key>
 	<string>Created with Recipe Robot v2.3.1 (https://github.com/homebysix/recipe-robot)</string>
 	<key>Description</key>
-	<string>Downloads the latest version of OrbStack and creates a package.</string>
+	<string>Downloads the latest version of OrbStack and creates a package.
+
+For Apple Silicon use: "arm64" in the ARCH variable (default)
+For Intel use: "amd64" in the ARCH variable</string>
 	<key>Identifier</key>
 	<string>com.github.arubdesu.pkg.OrbStack</string>
 	<key>Input</key>
 	<dict>
+		<key>ARCH</key>
+		<string>arm64</string>
 		<key>NAME</key>
 		<string>OrbStack</string>
 	</dict>


### PR DESCRIPTION
This converts the `DOWNLOAD_ARCH` variable to `ARCH` and expands it to automatically set Munki's supported architecture array via FindAndReplace.

`-vv` logs for all eight runs are attached:

[download-amd64.txt](https://github.com/user-attachments/files/17963442/download-amd64.txt)
[download-arm64.txt](https://github.com/user-attachments/files/17963443/download-arm64.txt)
[install-amd64.txt](https://github.com/user-attachments/files/17963444/install-amd64.txt)
[install-arm64.txt](https://github.com/user-attachments/files/17963445/install-arm64.txt)
[munki-amd64.txt](https://github.com/user-attachments/files/17963446/munki-amd64.txt)
[munki-arm64.txt](https://github.com/user-attachments/files/17963447/munki-arm64.txt)
[pkg-amd64.txt](https://github.com/user-attachments/files/17963448/pkg-amd64.txt)
[pkg-arm64.txt](https://github.com/user-attachments/files/17963449/pkg-arm64.txt)
