### PR TITLE
Fix Puppet recipes

### DIFF
--- a/Puppetlabs/PuppetEnterpriseAgent.download.recipe
+++ b/Puppetlabs/PuppetEnterpriseAgent.download.recipe
@@ -6,7 +6,10 @@
 	<string>Downloads the current release version of PuppetEnterpriseAgent.
 
 OS_VERSION can be overridden for the specific package, or left to the current
-latest OS available</string>
+latest OS available
+
+Set ARCH to "x86_64" for Intel or "arm64" for Apple Silicon.
+</string>
 	<key>Identifier</key>
 	<string>com.github.autopkg.arubdesu-recipes.download.PuppetEnterpriseAgent</string>
 	<key>Input</key>
@@ -14,7 +17,11 @@ latest OS available</string>
 		<key>NAME</key>
 		<string>PuppetEnterpriseAgent</string>
 		<key>OS_VERSION</key>
-		<string>11</string>
+		<string>14</string>
+		<key>PUPPET_VERSION</key>
+		<string>8</string>
+		<key>ARCH</key>
+		<string>x86_64</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.6.1</string>
@@ -22,22 +29,11 @@ latest OS available</string>
 	<array>
 		<dict>
 			<key>Processor</key>
-			<string>URLTextSearcher</string>
-			<key>Arguments</key>
-			<dict>
-				<key>url</key>
-				<string>https://s3.amazonaws.com/puppet-agents/?max-keys=9000&amp;prefix=2016.4/puppet-agent-latest/repos/apple/10.%OS_VERSION%/PC1/x86_64</string>
-				<key>re_pattern</key>
-				<string>Key&gt;(.*\.dmg)&lt;</string>
-			</dict>
-		</dict>
-		<dict>
-			<key>Processor</key>
 			<string>URLDownloader</string>
 			<key>Arguments</key>
 			<dict>
 				<key>url</key>
-				<string>https://s3.amazonaws.com/puppet-agents/%match%</string>
+				<string>https://downloads.puppetlabs.com/mac/puppet%PUPPET_VERSION%/%OS_VERSION%/%ARCH%/puppet-agent-latest.dmg</string>
 			</dict>
 		</dict>
 		<dict>


### PR DESCRIPTION
This PR adjusts the download method for obtaining the latest Puppet agent for Mac.

Double check my work here — I'm not a Puppet user but I think I derived the proper file to grab.

Verbose recipe run output with default (Intel) architecture:

```
% autopkg run -vvq 'Puppetlabs/PuppetEnterpriseAgent.download.recipe'
Processing Puppetlabs/PuppetEnterpriseAgent.download.recipe...
WARNING: Puppetlabs/PuppetEnterpriseAgent.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLDownloader
{'Input': {'url': 'https://downloads.puppetlabs.com/mac/puppet8/14/x86_64/puppet-agent-latest.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Tue, 22 Oct 2024 21:35:47 GMT
URLDownloader: Storing new ETag header: "452d42eb8c3d796854b924706424b55e-6"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.autopkg.arubdesu-recipes.download.PuppetEnterpriseAgent/downloads/puppet-agent-latest.dmg
{'Output': {'download_changed': True,
            'etag': '"452d42eb8c3d796854b924706424b55e-6"',
            'last_modified': 'Tue, 22 Oct 2024 21:35:47 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.autopkg.arubdesu-recipes.download.PuppetEnterpriseAgent/downloads/puppet-agent-latest.dmg',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.autopkg.arubdesu-recipes.download.PuppetEnterpriseAgent/downloads/puppet-agent-latest.dmg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'expected_authority_names': ['Developer ID Installer: PUPPET LABS, '
                                        'INC. (VKGLGN2B6Y)',
                                        'Developer ID Certification Authority',
                                        'Apple Root CA'],
           'input_path': '~/Library/AutoPkg/Cache/com.github.autopkg.arubdesu-recipes.download.PuppetEnterpriseAgent/downloads/puppet-agent-latest.dmg/*.pkg'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.autopkg.arubdesu-recipes.download.PuppetEnterpriseAgent/downloads/puppet-agent-latest.dmg
CodeSignatureVerifier: Using path '/private/tmp/dmg.2FxAQe/puppet-agent-8.10.0-1-installer.pkg' matched from globbed '/private/tmp/dmg.2FxAQe/*.pkg'.
CodeSignatureVerifier: Verifying installer package signature...
CodeSignatureVerifier: Package "puppet-agent-8.10.0-1-installer.pkg":
CodeSignatureVerifier:    Status: signed by a developer certificate issued by Apple for distribution
CodeSignatureVerifier:    Signed with a trusted timestamp on: 2024-10-18 15:15:25 +0000
CodeSignatureVerifier:    Certificate Chain:
CodeSignatureVerifier:     1. Developer ID Installer: PUPPET LABS, INC. (VKGLGN2B6Y)
CodeSignatureVerifier:        Expires: 2027-02-01 22:12:15 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            E7 20 70 F7 45 FC 8C C1 AE FC 47 C3 9A C0 10 BB 2D F0 F3 2A BA A1
CodeSignatureVerifier:            E3 3D 63 61 3C 16 CB 63 BE 8E
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     2. Developer ID Certification Authority
CodeSignatureVerifier:        Expires: 2027-02-01 22:12:15 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            7A FC 9D 01 A6 2F 03 A2 DE 96 37 93 6D 4A FE 68 09 0D 2D E1 8D 03
CodeSignatureVerifier:            F2 9C 88 CF B0 B1 BA 63 58 7F
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     3. Apple Root CA
CodeSignatureVerifier:        Expires: 2035-02-09 21:40:36 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            B0 B1 73 0E CB C7 FF 45 05 14 2C 49 F1 29 5E 6E DA 6B CA ED 7E 2C
CodeSignatureVerifier:            68 C5 BE 91 B5 A1 10 01 F0 24
CodeSignatureVerifier:
CodeSignatureVerifier: Signature is valid
CodeSignatureVerifier: Authority name chain is valid
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.autopkg.arubdesu-recipes.download.PuppetEnterpriseAgent/receipts/PuppetEnterpriseAgent.download-receipt-20241229-000651.plist

The following new items were downloaded:
    Download Path
    -------------
    ~/Library/AutoPkg/Cache/com.github.autopkg.arubdesu-recipes.download.PuppetEnterpriseAgent/downloads/puppet-agent-latest.dmg
```

Verbose recipe run output with Apple Silicon architecture:

```
% autopkg run -vvq 'Puppetlabs/PuppetEnterpriseAgent.download.recipe' -k ARCH=arm64
Processing Puppetlabs/PuppetEnterpriseAgent.download.recipe...
WARNING: Puppetlabs/PuppetEnterpriseAgent.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLDownloader
{'Input': {'url': 'https://downloads.puppetlabs.com/mac/puppet8/14/arm64/puppet-agent-latest.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Tue, 22 Oct 2024 21:35:46 GMT
URLDownloader: Storing new ETag header: "4c21cd4844727d0f7b9a566d15be8774-6"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.autopkg.arubdesu-recipes.download.PuppetEnterpriseAgent/downloads/puppet-agent-latest.dmg
{'Output': {'download_changed': True,
            'etag': '"4c21cd4844727d0f7b9a566d15be8774-6"',
            'last_modified': 'Tue, 22 Oct 2024 21:35:46 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.autopkg.arubdesu-recipes.download.PuppetEnterpriseAgent/downloads/puppet-agent-latest.dmg',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.autopkg.arubdesu-recipes.download.PuppetEnterpriseAgent/downloads/puppet-agent-latest.dmg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'expected_authority_names': ['Developer ID Installer: PUPPET LABS, '
                                        'INC. (VKGLGN2B6Y)',
                                        'Developer ID Certification Authority',
                                        'Apple Root CA'],
           'input_path': '~/Library/AutoPkg/Cache/com.github.autopkg.arubdesu-recipes.download.PuppetEnterpriseAgent/downloads/puppet-agent-latest.dmg/*.pkg'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.autopkg.arubdesu-recipes.download.PuppetEnterpriseAgent/downloads/puppet-agent-latest.dmg
CodeSignatureVerifier: Using path '/private/tmp/dmg.fTPqzI/puppet-agent-8.10.0-1-installer.pkg' matched from globbed '/private/tmp/dmg.fTPqzI/*.pkg'.
CodeSignatureVerifier: Verifying installer package signature...
CodeSignatureVerifier: Package "puppet-agent-8.10.0-1-installer.pkg":
CodeSignatureVerifier:    Status: signed by a developer certificate issued by Apple for distribution
CodeSignatureVerifier:    Signed with a trusted timestamp on: 2024-10-18 15:16:37 +0000
CodeSignatureVerifier:    Certificate Chain:
CodeSignatureVerifier:     1. Developer ID Installer: PUPPET LABS, INC. (VKGLGN2B6Y)
CodeSignatureVerifier:        Expires: 2027-02-01 22:12:15 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            E7 20 70 F7 45 FC 8C C1 AE FC 47 C3 9A C0 10 BB 2D F0 F3 2A BA A1
CodeSignatureVerifier:            E3 3D 63 61 3C 16 CB 63 BE 8E
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     2. Developer ID Certification Authority
CodeSignatureVerifier:        Expires: 2027-02-01 22:12:15 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            7A FC 9D 01 A6 2F 03 A2 DE 96 37 93 6D 4A FE 68 09 0D 2D E1 8D 03
CodeSignatureVerifier:            F2 9C 88 CF B0 B1 BA 63 58 7F
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     3. Apple Root CA
CodeSignatureVerifier:        Expires: 2035-02-09 21:40:36 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            B0 B1 73 0E CB C7 FF 45 05 14 2C 49 F1 29 5E 6E DA 6B CA ED 7E 2C
CodeSignatureVerifier:            68 C5 BE 91 B5 A1 10 01 F0 24
CodeSignatureVerifier:
CodeSignatureVerifier: Signature is valid
CodeSignatureVerifier: Authority name chain is valid
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.autopkg.arubdesu-recipes.download.PuppetEnterpriseAgent/receipts/PuppetEnterpriseAgent.download-receipt-20241229-000816.plist

The following new items were downloaded:
    Download Path
    -------------
    ~/Library/AutoPkg/Cache/com.github.autopkg.arubdesu-recipes.download.PuppetEnterpriseAgent/downloads/puppet-agent-latest.dmg
```
