### PR TITLE
Change parent recipe of balenaEtcher.install

### DIFF
--- a/balena-io/balenaEtcher.download.recipe
+++ b/balena-io/balenaEtcher.download.recipe
@@ -14,9 +14,18 @@
 		<string>balenaEtcher</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>1.0.0</string>
+	<string>1.1</string>
 	<key>Process</key>
 	<array>
+		<dict>
+			<key>Processor</key>
+			<string>DeprecationWarning</string>
+			<key>Arguments</key>
+			<dict>
+				<key>warning_message</key>
+				<string>Consider switching to the balenaEtcher recipes in the dataJAR-recipes or ahousseini-recipes repos. This recipe is deprecated and will be removed in the future.</string>
+			</dict>
+		</dict>
 		<dict>
 			<key>Arguments</key>
 			<dict>

--- a/balena-io/balenaEtcher.install.recipe
+++ b/balena-io/balenaEtcher.install.recipe
@@ -16,7 +16,7 @@
 	<key>MinimumVersion</key>
 	<string>1.0.0</string>
 	<key>ParentRecipe</key>
-	<string>com.github.autopkg.arubdesu-recipes.download.balenaEtcher</string>
+	<string>com.github.dataJAR-recipes.download.balenaEtcher</string>
 	<key>Process</key>
 	<array>
 		<dict>


### PR DESCRIPTION
This PR switches the parent recipe of balenaEtcher.install to dataJAR's download recipe, and deprecates the download recipe in this repo.