### PR TITLE
Fix Charles Proxy download

### DIFF
--- a/CharlesProxy/CharlesProxy.download.recipe
+++ b/CharlesProxy/CharlesProxy.download.recipe
@@ -26,6 +26,11 @@
 				<string>%URL%</string>
 				<key>re_pattern</key>
 				<string>.*</string>
+				<key>curl_opts</key>
+				<array>
+					<string>-X</string>
+					<string>POST</string>
+				</array>
 			</dict>
 		</dict>
 		<dict>
@@ -33,6 +38,11 @@
 			<dict>
 				<key>url</key>
 				<string>https://www.charlesproxy.com/assets/release/%match%/charles-proxy-%match%.dmg</string>
+				<key>curl_opts</key>
+				<array>
+					<string>-X</string>
+					<string>GET</string>
+				</array>
 			</dict>
 			<key>Processor</key>
 			<string>URLDownloader</string>


### PR DESCRIPTION
A change on the Charles Proxy website now requires a POST to the /latest.do endpoint.

The download url is still uses GET so we need to set the curl_opts back to GET after searching for the latest version number.

```
URLTextSearcher
{'Input': {'curl_opts': ['-X', 'POST'],
           're_pattern': '.*',
           'url': 'https://www.charlesproxy.com/latest.do'}}
URLTextSearcher: No value supplied for result_output_var_name, setting default value of: match
URLTextSearcher: Curl command: ['/usr/bin/curl', '--compressed', '--location', '-X', 'POST', 'https://www.charlesproxy.com/latest.do']
URLTextSearcher: Found matching text (match): 5.0.1
{'Output': {'match': '5.0.1'}}
URLDownloader
{'Input': {'curl_opts': ['-X', 'GET'],
           'url': 'https://www.charlesproxy.com/assets/release/5.0.1/charles-proxy-5.0.1.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Curl command: ['/usr/bin/curl', '--silent', '--show-error', '--no-buffer', '--dump-header', '-', '--speed-time', '30', '--location', '--url', 'https://www.charlesproxy.com/assets/release/5.0.1/charles-proxy-5.0.1.dmg', '--fail', '--output', '/Users/victor_desouza/Library/AutoPkg/Cache/local.munki.CharlesProxy/downloads/tmp2dmjyn2n', '-X', 'GET']
URLDownloader: Storing new Last-Modified header: Thu, 15 May 2025 01:07:26 GMT
URLDownloader: Storing new ETag header: "68253e4e-47e6bf9"
URLDownloader: Downloaded /Users/victor_desouza/Library/AutoPkg/Cache/local.munki.CharlesProxy/downloads/charles-proxy-5.0.1.dmg
{'Output': {'download_changed': True,
            'etag': '"68253e4e-47e6bf9"',
            'last_modified': 'Thu, 15 May 2025 01:07:26 GMT',
            'pathname': '/Users/victor_desouza/Library/AutoPkg/Cache/local.munki.CharlesProxy/downloads/charles-proxy-5.0.1.dmg',
            'url_downloader_summary_result': {'data': {'download_path': '/Users/victor_desouza/Library/AutoPkg/Cache/local.munki.CharlesProxy/downloads/charles-proxy-5.0.1.dmg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
```