### PR TITLE
Removal of unused `options` from PkgCreator arguments

### DIFF
--- a/CelestialTeapotSoftware/Fake.pkg.recipe
+++ b/CelestialTeapotSoftware/Fake.pkg.recipe
@@ -70,8 +70,6 @@
                     <string>%version%</string>
                     <key>id</key>
                     <string>com.fakeapp.Fake</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>chown</key>
                     <array>
                         <dict>

--- a/CelestialTeapotSoftware/Fluid.pkg.recipe
+++ b/CelestialTeapotSoftware/Fluid.pkg.recipe
@@ -70,8 +70,6 @@
                     <string>%version%</string>
                     <key>id</key>
                     <string>com.fluidapp.FluidApp</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>chown</key>
                     <array>
                         <dict>

--- a/CharlesProxy/CharlesProxy.pkg.recipe
+++ b/CharlesProxy/CharlesProxy.pkg.recipe
@@ -64,8 +64,6 @@
 					<string>%RECIPE_CACHE_DIR%</string>
 					<key>id</key>
 					<string>com.xk72.Charles</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>chown</key>
 					<array>
 						<dict>

--- a/ClipMenu/ClipMenu.pkg.recipe
+++ b/ClipMenu/ClipMenu.pkg.recipe
@@ -64,8 +64,6 @@
                     <string>%RECIPE_CACHE_DIR%</string>
                     <key>id</key>
                     <string>com.naotaka.ClipMenu</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>chown</key>
                     <array>
                         <dict>

--- a/Google PythonAppEngineSDK/GoogleAppEngineLauncher.pkg.recipe
+++ b/Google PythonAppEngineSDK/GoogleAppEngineLauncher.pkg.recipe
@@ -64,8 +64,6 @@
 					</array>
 					<key>id</key>
 					<string>%BUNDLE_ID%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%-%version%</string>
 					<key>pkgroot</key>

--- a/IrradiatedSoftware/Cinch.pkg.recipe
+++ b/IrradiatedSoftware/Cinch.pkg.recipe
@@ -70,8 +70,6 @@
                     <string>%version%</string>
                     <key>id</key>
                     <string>com.irradiatedsoftware.cinch</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>chown</key>
                     <array>
                         <dict>

--- a/Limechat/Limechat.pkg.recipe
+++ b/Limechat/Limechat.pkg.recipe
@@ -70,8 +70,6 @@
                     <string>%version%</string>
                     <key>id</key>
                     <string>net.limechat.limechat</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>chown</key>
                     <array>
                         <dict>

--- a/MacID/MacID.pkg.recipe
+++ b/MacID/MacID.pkg.recipe
@@ -70,8 +70,6 @@
 					<string>%version%</string>
 					<key>id</key>
 					<string>com.kanecheshire.MacIDOSX</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>chown</key>
 					<array>
 						<dict>

--- a/Mactracker/Mactracker.pkg.recipe
+++ b/Mactracker/Mactracker.pkg.recipe
@@ -70,8 +70,6 @@
                     <string>%version%</string>
                     <key>id</key>
                     <string>com.mactrackerapp.Mactracker</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>chown</key>
                     <array>
                         <dict>

--- a/OnCue/OnCue2.pkg.recipe
+++ b/OnCue/OnCue2.pkg.recipe
@@ -57,8 +57,6 @@
                     <string>%version%</string>
                     <key>id</key>
                     <string>com.eggdevil.oncue2</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>chown</key>
                     <array>
                         <dict>

--- a/Pacifist/Pacifist.pkg.recipe
+++ b/Pacifist/Pacifist.pkg.recipe
@@ -64,8 +64,6 @@
                     <string>%version%</string>
                     <key>id</key>
                     <string>com.charlessoft.pacifist</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>chown</key>
                     <array>
                         <dict>

--- a/PeterBorgApps/LingonX.pkg.recipe
+++ b/PeterBorgApps/LingonX.pkg.recipe
@@ -70,8 +70,6 @@
                     <string>%version%</string>
                     <key>id</key>
                     <string>com.peterborgapps.LingonX</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>chown</key>
                     <array>
                         <dict>

--- a/QuickRadar/quickradar.pkg.recipe
+++ b/QuickRadar/quickradar.pkg.recipe
@@ -70,8 +70,6 @@
                     <string>%version%</string>
                     <key>id</key>
                     <string>com.quickradar.QuickRadar</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>chown</key>
                     <array>
                         <dict>

--- a/RedSweater/MarsEdit.pkg.recipe
+++ b/RedSweater/MarsEdit.pkg.recipe
@@ -70,8 +70,6 @@
                     <string>%version%</string>
                     <key>id</key>
                     <string>com.red-sweater.marsedit</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>chown</key>
                     <array>
                         <dict>

--- a/Reflector/Reflector.pkg.recipe
+++ b/Reflector/Reflector.pkg.recipe
@@ -64,8 +64,6 @@
                     <string>%RECIPE_CACHE_DIR%</string>
                     <key>id</key>
                     <string>com.squirrels.Reflection</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>chown</key>
                     <array>
                         <dict>

--- a/Sonos/Sonos.pkg.recipe
+++ b/Sonos/Sonos.pkg.recipe
@@ -64,8 +64,6 @@
 					<string>%RECIPE_CACHE_DIR%</string>
 					<key>id</key>
 					<string>com.sonos.macController</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>chown</key>
 					<array>
 						<dict>

--- a/WWDC/WWDC.pkg.recipe
+++ b/WWDC/WWDC.pkg.recipe
@@ -39,8 +39,6 @@
 					</array>
 					<key>id</key>
 					<string>%BUNDLE_ID%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%-%version%</string>
 					<key>pkgroot</key>

--- a/aws-vault/aws-vault.pkg.recipe
+++ b/aws-vault/aws-vault.pkg.recipe
@@ -58,8 +58,6 @@
 					<string>%NAME%-%version%</string>
 					<key>id</key>
 					<string>com.99designs.%NAME%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>chown</key>
 					<array>
 						<dict>

--- a/iTeleport/iTeleport.pkg.recipe
+++ b/iTeleport/iTeleport.pkg.recipe
@@ -70,8 +70,6 @@
                     <string>%version%</string>
                     <key>id</key>
                     <string>com.iteleport.iteleportformac</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>chown</key>
                     <array>
                         <dict>


### PR DESCRIPTION
Hundreds of recipes dating from the very beginning of AutoPkg use the `options` key in the `pkg_request` argument of PkgCreator:

```xml
<key>options</key>
<string>purge_ds_store</string>
```

However, this key doesn't serve any purpose at all. The `options` key is ignored and not passed along to `pkgbuild`, regardless of its presence or contents. It appears that this has been the case since the very first public release of AutoPkg 0.1.0!

So this pull request (one of over 100) formally ends this practice and removes the unused and unneeded `options` key from all recipes in the AutoPkg org that use PkgCreator.

Thanks for considering!

_This PR was submitted using [Repo Lasso](https://github.com/homebysix/repo-lasso) v1.2.0._